### PR TITLE
Remove duplicate native tooltips on exported line chart

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,22 @@
 # FKI Kalk projekt
+
+Interaktivní webová kalkulačka pro správu investičního portfolia.
+
+## Klíčové funkce
+- Moderní zadávací formuláře pro poskytovatele AVANT, CODYA, ATRIS a J&T
+- Automatické výpočty výkonnosti (XIRR, kumulativní výnos, vážená doba investice)
+- Vizualizace prostřednictvím liniového a koláčového grafu
+- Kalkulačka nekonečné renty a upozornění na chybějící data
+- Přímý export do JSONu pro zálohování nebo opětovný import
+- **Export prezentace pro klienta** – generuje statický HTML report připravený ke sdílení offline
+- Možnost **zmrazit** jednotlivé fondy: zůstanou v přehledu, ale neovlivňují souhrnné výnosy, projekce ani kalkulačku renty
+
+## Jak exportovat klientský report
+1. Vyplňte všechna potřebná data ve fondech a zkontrolujte výsledky.
+2. V části *Správa dat* zadejte jméno a příjmení klienta (1. pád) a připravte si také oslovení v 5. pádě (např. "Pepo", "paní Nováková"). Obojí je povinné pro export.
+3. Zvolte pohlaví klienta a preferovanou formu komunikace (**tykání** nebo **vykání**). Všechny texty v exportu se podle kombinace voleb automaticky přizpůsobí.
+4. Vyberte jazyk reportu (čeština nebo angličtina). Anglická varianta automaticky přepne slovosled, gramatiku i formátování čísel.
+5. Volitelně doplňte směnný kurz, pokud pracujete s více měnami.
+6. Klikněte na tlačítko **„Exportovat report pro klienta (.html)”** – stáhne se samostatný soubor s interaktivní prezentací grafů a tabulek.
+
+Exportovaný HTML soubor je plně statický, nevyžaduje připojení k internetu a zachovává vzhled i aktuální čísla z kalkulačky v okamžiku exportu.

--- a/index.html
+++ b/index.html
@@ -2150,19 +2150,22 @@ document.addEventListener('DOMContentLoaded', () => {
         const ariaAttr = htmlEscape(exportChart.ariaLabel || 'Vývoj portfolia');
         /* PATCH */
         /* PATCH: robustly encode hover payloads for export tooltip hydration */
+        /* PATCH: encode hover/meta payloads but keep decoding flexible in the bootstrapper */
         const pointsPayload = exportChart.hoverPoints
             ? encodeURIComponent(JSON.stringify(exportChart.hoverPoints))
             : '';
         /* PATCH */
         const viewBoxPayload = exportChart.viewBox ? `${exportChart.viewBox.width},${exportChart.viewBox.height}` : '';
         /* PATCH */
-        const metaPayload = encodeURIComponent(JSON.stringify({
-            locale: currencyFormat.locale || 'cs-CZ',
-            generic: exportChart.hoverTemplate || '__DATE__\n__VALUE__'
-        }));
+        const metaPayload = exportChart.hoverTemplate
+            ? encodeURIComponent(JSON.stringify({
+                locale: currencyFormat.locale || 'cs-CZ',
+                generic: exportChart.hoverTemplate
+            }))
+            : '';
         /* PATCH */
         const canvasAttrs = pointsPayload
-            ? `class="line-canvas" role="img" aria-label="${ariaAttr}" data-line-points="${pointsPayload}" data-viewbox="${viewBoxPayload}" data-line-meta="${metaPayload}"`
+            ? `class="line-canvas" role="img" aria-label="${ariaAttr}" data-line-points="${pointsPayload}" data-viewbox="${viewBoxPayload}" ${metaPayload ? `data-line-meta="${metaPayload}"` : ''}`
             : `class="line-canvas" role="img" aria-label="${ariaAttr}"`;
         return `<div class="line-export">${legend}<div ${canvasAttrs}>${exportChart.svg}</div>${footnote}</div>`;
     }
@@ -3624,14 +3627,18 @@ document.addEventListener('DOMContentLoaded', () => {
         });
         document.addEventListener('mouseout',e=>{if(!e.target.closest('[data-tooltip-text]'))return;hide();});
         const attachLineCharts=()=>{
+          const parsePayload=(raw)=>{
+            if(!raw)return null;
+            const attempts=[() => JSON.parse(raw),() => JSON.parse(decodeURIComponent(raw))];
+            for(const attempt of attempts){try{return attempt();}catch(_e){}}
+            return null;
+          };
           document.querySelectorAll('.line-canvas[data-line-points]').forEach(canvas=>{
             const raw=canvas.getAttribute('data-line-points');
-            let pts;try{pts=JSON.parse(decodeURIComponent(raw));}catch(_e){return;}
-            if(!pts||!pts.length)return;
+            const pts=parsePayload(raw);
+            if(!Array.isArray(pts)||!pts.length)return;
             /* PATCH */
-            let meta={};
-            const metaRaw=canvas.getAttribute('data-line-meta');
-            try{meta=JSON.parse(decodeURIComponent(metaRaw));}catch(_e){}
+            const meta=parsePayload(canvas.getAttribute('data-line-meta'))||{};
             const locale=meta.locale||'cs-CZ';
             const genericTemplate=meta.generic||'__DATE__\n__VALUE__';
             const fmtInt=new Intl.NumberFormat(locale,{maximumFractionDigits:0});

--- a/index.html
+++ b/index.html
@@ -1,0 +1,3900 @@
+<!doctype html>
+<html lang="cs">
+<head>
+  <meta charset="utf-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <title>Report investičního portfolia</title>
+  <script src="https://cdn.tailwindcss.com"></script>
+  <style>
+    @import url('https://fonts.googleapis.com/css2?family=Montserrat:wght@400;500;600;700&display=swap');
+
+    :root {
+        color-scheme: light;
+        --color-bg-start: #FDFEFF;
+        --color-bg-end: #F8F9FA;
+        --color-primary: #0d2c54;
+        --color-accent: #4DB1C8;
+        --color-text: #33373D;
+        --color-muted: #888B90;
+        --color-border: #EAECEE;
+        --color-border-strong: #D0E0E8;
+        --color-card: #FFFFFF;
+        --color-shadow: 0 10px 25px -10px rgba(13, 44, 84, 0.1);
+        --color-shadow-strong: 0 18px 38px -18px rgba(13, 44, 84, 0.15);
+    }
+
+    html, body {
+        font-family: 'Montserrat', ui-sans-serif, system-ui, -apple-system, 'Segoe UI', Roboto, Arial, 'Helvetica Neue', sans-serif;
+        scroll-behavior: smooth;
+        min-height: 100%;
+        background: linear-gradient(180deg, var(--color-bg-start) 0%, var(--color-bg-end) 100%);
+        color: var(--color-text);
+    }
+
+    .tabular { font-variant-numeric: tabular-nums; }
+    .hidden { display: none !important; }
+    button:disabled { opacity: .5; cursor: not-allowed; }
+    .editable[contenteditable="true"]:empty:before {
+        content: attr(data-ph);
+        color: var(--color-muted);
+        pointer-events: none;
+        display: block;
+    }
+    .editable {
+        outline: none;
+        border: 1px solid var(--color-border);
+        border-radius: 0.9rem;
+        padding: 0.6rem 0.75rem;
+        background: #fff;
+        transition: border-color 0.2s ease, box-shadow 0.2s ease;
+    }
+    .editable:focus {
+        border-color: var(--color-accent);
+        box-shadow: 0 0 0 4px rgba(77, 177, 200, 0.18);
+    }
+
+    input[type=number]::-webkit-inner-spin-button,
+    input[type=number]::-webkit-outer-spin-button {
+      -webkit-appearance: none;
+      margin: 0;
+    }
+    input[type=number] { -moz-appearance: textfield; }
+
+    @keyframes fadeIn {
+        from { opacity: 0; transform: translateY(-10px); }
+        to { opacity: 1; transform: translateY(0); }
+    }
+    .fade-in { animation: fadeIn 0.3s ease-out forwards; }
+
+    @keyframes fadeOut {
+        from { opacity: 1; transform: scale(0.95); }
+        to { opacity: 0; transform: scale(1); }
+    }
+    .fade-out { animation: fadeOut 0.3s ease-in forwards; }
+
+    details > summary { list-style: none; }
+    details > summary::-webkit-details-marker { display: none; }
+    details > summary .summary-arrow { transition: transform 0.2s; }
+    details[open] > summary .summary-arrow { transform: rotate(90deg); }
+
+    #toast-container {
+        position: fixed;
+        top: 1.5rem;
+        right: 1.5rem;
+        z-index: 50;
+        display: flex;
+        flex-direction: column;
+        gap: 0.75rem;
+    }
+    .toast {
+        display: flex;
+        align-items: center;
+        gap: 0.75rem;
+        padding: 0.9rem 1.15rem;
+        border-radius: 1rem;
+        box-shadow: var(--color-shadow);
+        border: 1px solid var(--color-border);
+        background-color: var(--color-card);
+        color: var(--color-text);
+        opacity: 0;
+        transform: translateX(100%);
+        transition: all 0.35s cubic-bezier(0.21, 1.02, 0.73, 1);
+    }
+    .toast.show {
+        opacity: 1;
+        transform: translateX(0);
+    }
+    .toast-success { background-color: rgba(77, 177, 200, 0.12); border-color: rgba(77, 177, 200, 0.35); color: var(--color-primary); }
+    .toast-error { background-color: rgba(220, 53, 69, 0.14); border-color: rgba(220, 53, 69, 0.35); color: #b91c1c; }
+
+    #chart-tooltip {
+        position: absolute;
+        z-index: 20;
+        transition: opacity 0.2s;
+        pointer-events: none;
+        background: var(--color-card);
+        border: 1px solid var(--color-border);
+        color: var(--color-text);
+        border-radius: 0.75rem;
+        box-shadow: var(--color-shadow);
+        padding: 0.5rem 0.75rem;
+        opacity: 0;
+        max-width: min(320px, 90vw);
+        overflow-wrap: anywhere;
+    }
+
+    /* PATCH */
+    .card {
+        background: radial-gradient(circle at 18% 20%, rgba(77, 177, 200, 0.08), transparent 42%),
+            radial-gradient(circle at 85% 15%, rgba(13, 44, 84, 0.06), transparent 38%),
+            var(--color-card);
+        border: 1px solid var(--color-border);
+        border-radius: 1.5rem;
+        box-shadow: var(--color-shadow);
+        padding: 1.5rem;
+        transition: transform 0.25s ease, box-shadow 0.25s ease, border-color 0.25s ease, background 0.25s ease;
+    }
+
+    /* PATCH */
+    .freeze-toggle {
+        display: inline-flex;
+        align-items: center;
+        gap: 0.3rem;
+        padding: 0.3rem 0.6rem;
+        border-radius: 0.75rem;
+        border: 1px solid rgba(13, 44, 84, 0.18);
+        background: rgba(77, 177, 200, 0.12);
+        color: var(--brand-ink, #0b2b5e);
+        font-size: 0.72rem;
+        font-weight: 600;
+        transition: background 0.2s ease, color 0.2s ease, border-color 0.2s ease;
+    }
+
+    /* PATCH */
+    .freeze-toggle[aria-pressed="true"] {
+        background: rgba(13, 44, 84, 0.12);
+        color: #0b2b5e;
+        border-color: rgba(13, 44, 84, 0.3);
+    }
+
+    /* PATCH */
+    .is-frozen-row {
+        opacity: 0.7;
+    }
+
+    /* PATCH */
+    .freeze-badge {
+        display: inline-flex;
+        align-items: center;
+        gap: 0.35rem;
+        padding: 0.25rem 0.65rem;
+        border-radius: 999px;
+        background: rgba(13, 44, 84, 0.08);
+        color: var(--brand-ink, #0b2b5e);
+        font-size: 0.7rem;
+        font-weight: 600;
+        letter-spacing: 0.02em;
+    }
+    @media (min-width: 640px) {
+        .card { padding: 2rem; }
+    }
+
+    .card:hover {
+        transform: translateY(-4px);
+        border-color: var(--color-border-strong);
+        box-shadow: var(--color-shadow-strong);
+        background: radial-gradient(circle at 20% 18%, rgba(77, 177, 200, 0.12), transparent 45%),
+            radial-gradient(circle at 80% 12%, rgba(13, 44, 84, 0.08), transparent 42%),
+            var(--color-card);
+    }
+
+    .primary-btn, .secondary-btn, .danger-btn {
+        display: inline-flex;
+        align-items: center;
+        justify-content: center;
+        gap: 0.5rem;
+        border-radius: 0.9rem;
+        padding: 0.65rem 1.1rem;
+        font-weight: 600;
+        font-size: 0.95rem;
+        transition: background 0.2s ease, color 0.2s ease, box-shadow 0.2s ease, border-color 0.2s ease;
+    }
+
+    .primary-btn {
+        background: var(--color-primary);
+        color: #fff;
+        border: 1px solid var(--color-primary);
+        box-shadow: var(--color-shadow);
+    }
+    .primary-btn:hover {
+        box-shadow: var(--color-shadow-strong);
+        background: #143d76;
+        border-color: #143d76;
+    }
+
+    .secondary-btn {
+        background: rgba(77, 177, 200, 0.12);
+        color: var(--color-primary);
+        border: 1px solid rgba(77, 177, 200, 0.4);
+    }
+    .secondary-btn:hover {
+        background: rgba(77, 177, 200, 0.18);
+        border-color: rgba(77, 177, 200, 0.55);
+    }
+
+    .danger-btn {
+        background: rgba(220, 53, 69, 0.08);
+        color: #b91c1c;
+        border: 1px solid rgba(220, 53, 69, 0.35);
+    }
+    .danger-btn:hover {
+        background: rgba(220, 53, 69, 0.14);
+        border-color: rgba(220, 53, 69, 0.45);
+    }
+
+    .glass-input {
+        background: rgba(255, 255, 255, 0.92);
+        border: 1px solid var(--color-border);
+        border-radius: 0.9rem;
+        padding: 0.6rem 0.75rem;
+        transition: border-color 0.2s ease, box-shadow 0.2s ease;
+    }
+    .glass-input::placeholder {
+        color: var(--color-muted);
+    }
+    .glass-input:focus {
+        border-color: var(--color-accent);
+        box-shadow: 0 0 0 4px rgba(77, 177, 200, 0.18);
+        outline: none;
+    }
+
+    .form-checkbox {
+        width: 1.05rem;
+        height: 1.05rem;
+        border-radius: 0.35rem;
+        border: 1px solid var(--color-border);
+        accent-color: var(--color-accent);
+    }
+
+    h1.report-title {
+        font-size: 3.333rem;
+        font-weight: 700;
+        color: var(--color-primary);
+        margin: 0;
+        text-transform: uppercase;
+        letter-spacing: 0.08em;
+    }
+    h2.section-title {
+        font-size: 2.167rem;
+        font-weight: 700;
+        color: var(--color-primary);
+        margin: 0;
+    }
+    h3.card-subtitle {
+        font-size: 1.125rem;
+        font-weight: 600;
+        color: var(--color-text);
+        margin: 0;
+    }
+    p {
+        font-size: 1.167rem;
+        line-height: 1.6;
+        color: var(--color-text);
+    }
+    .muted-text { color: var(--color-muted); font-size: 0.85rem; }
+    .text-body { color: var(--color-text); }
+    .text-muted { color: var(--color-muted); }
+    .text-primary { color: var(--color-primary); }
+    .text-accent { color: var(--color-accent); }
+    .stat-value { font-size: 4rem; font-weight: 700; color: var(--color-accent); }
+    .pill {
+        display: inline-flex;
+        align-items: center;
+        gap: 0.45rem;
+        padding: 0.5rem 1.1rem;
+        border-radius: 999px;
+        background: rgba(13, 44, 84, 0.08);
+        color: var(--color-primary);
+        font-weight: 600;
+        font-size: 0.85rem;
+        letter-spacing: 0.08em;
+        text-transform: uppercase;
+    }
+    .border-subtle { border-color: var(--color-border) !important; }
+    .border-accent-soft { border-color: rgba(77, 177, 200, 0.35) !important; }
+    .bg-accent-soft { background: rgba(77, 177, 200, 0.12); }
+    #pie-time-slider { accent-color: var(--color-accent); }
+
+    .report-header {
+        padding: 4rem 1.5rem 2.5rem;
+    }
+    .report-header__inner {
+        max-width: 1200px;
+        margin: 0 auto;
+        display: flex;
+        flex-direction: column;
+        gap: 2.5rem;
+    }
+    .brand-logo {
+        font-size: 1.9rem;
+        font-weight: 700;
+        letter-spacing: 0.12em;
+        color: var(--color-primary);
+    }
+    .brand-logo span { color: var(--color-accent); }
+
+    .hero-layout {
+        display: grid;
+        gap: 2.5rem;
+        grid-template-columns: repeat(auto-fit, minmax(280px, 1fr));
+        align-items: start;
+    }
+    .hero-intro { display: flex; flex-direction: column; gap: 1.5rem; }
+    .hero-badges { display: flex; flex-wrap: wrap; gap: 1rem; }
+    .hero-badge {
+        background: rgba(13, 44, 84, 0.08);
+        color: var(--color-primary);
+        padding: 0.5rem 1rem;
+        border-radius: 999px;
+        font-weight: 600;
+        font-size: 0.85rem;
+        letter-spacing: 0.05em;
+        text-transform: uppercase;
+    }
+    .hero-disclaimer { font-size: 0.9rem; color: var(--color-muted); display: flex; flex-wrap: wrap; gap: 0.75rem; }
+
+    .feature-stack {
+        display: flex;
+        flex-direction: column;
+        gap: 1.2rem;
+    }
+    /* PATCH */
+    .feature-card {
+        background: linear-gradient(145deg, rgba(77, 177, 200, 0.07), transparent 46%), var(--color-card);
+        border: 1px solid var(--color-border);
+        border-radius: 1.5rem;
+        padding: 1.3rem 1.4rem;
+        display: flex;
+        gap: 1rem;
+        align-items: flex-start;
+        transition: transform 0.25s ease, box-shadow 0.25s ease, border-color 0.25s ease, background 0.25s ease;
+    }
+    /* PATCH */
+    .feature-card:hover {
+        transform: translateY(-3px);
+        border-color: var(--color-border-strong);
+        box-shadow: var(--color-shadow-strong);
+        background: linear-gradient(145deg, rgba(77, 177, 200, 0.12), transparent 50%), var(--color-card);
+    }
+    .feature-icon {
+        width: 42px;
+        height: 42px;
+        border-radius: 1rem;
+        background: rgba(77, 177, 200, 0.15);
+        color: var(--color-primary);
+        display: grid;
+        place-items: center;
+        flex-shrink: 0;
+    }
+    /* PATCH */
+    .benefit {
+        display: flex;
+        flex-direction: column;
+        align-items: flex-start;
+        gap: 0.45rem;
+        margin-block: 14px;
+    }
+    /* PATCH */
+    .benefit-title {
+        font-weight: 600;
+        color: var(--color-primary);
+    }
+    /* PATCH */
+    .benefit-desc {
+        opacity: 0.85;
+    }
+    .feature-text { display: flex; flex-direction: column; gap: 0.35rem; }
+    .feature-title { font-weight: 600; color: var(--color-primary); font-size: 1rem; }
+    .feature-desc { font-size: 0.95rem; color: var(--color-text); line-height: 1.5; }
+
+    .input-highlight {
+        border-color: var(--color-accent) !important;
+        box-shadow: 0 0 0 1px var(--color-accent);
+    }
+
+    .delete-row-button {
+        color: var(--color-muted);
+    }
+    .delete-row-button:hover {
+        color: #B2403D;
+        background: rgba(178, 64, 61, 0.08);
+    }
+
+    .divider { height: 1px; background: var(--color-border); }
+
+    .bg-card-soft { background: rgba(255, 255, 255, 0.85); }
+    .bg-card-muted { background: rgba(255, 255, 255, 0.7); }
+    .bg-divider { background: rgba(13, 44, 84, 0.12); }
+
+    /* PATCH */
+    .fund-avatar {
+        width: 100px;
+        height: 100px;
+        border-radius: 50%;
+        display: inline-flex;
+        align-items: center;
+        justify-content: center;
+        font-size: 2rem;
+        font-weight: 700;
+        color: #ffffff;
+        text-transform: uppercase;
+        box-shadow: var(--color-shadow);
+        background: var(--color-primary);
+        flex-shrink: 0;
+    }
+    .fund-card__header { display: grid; gap: 1.4rem; grid-template-columns: auto 1fr; align-items: center; }
+    .fund-card__name { font-size: 1.35rem; font-weight: 600; color: var(--color-primary); overflow-wrap: anywhere; }
+    .fund-card__dot { width: 0.8rem; height: 0.8rem; border-radius: 999px; box-shadow: 0 0 0 3px rgba(13,44,84,0.1); }
+    .fund-card__meta { display: flex; flex-wrap: wrap; gap: 0.6rem; font-size: 0.92rem; color: var(--color-muted); }
+    .fund-card__meta span { padding: 0.35rem 0.75rem; border-radius: 999px; background: rgba(77,177,200,0.14); color: var(--color-primary); font-weight: 500; }
+    .fund-card__metrics { display: grid; gap: 1rem; grid-template-columns: repeat(auto-fit, minmax(160px, 1fr)); }
+    .fund-card__metric { background: rgba(13,44,84,0.04); border: 1px solid rgba(13,44,84,0.08); border-radius: 1.1rem; padding: 1rem 1.1rem; display: flex; flex-direction: column; gap: 0.5rem; }
+    .fund-card__metric .metric-label { color: var(--color-muted); }
+    .fund-card__metric .metric-value { color: var(--color-primary); font-weight: 600; }
+    .fund-card__transactions { border-radius: 1.2rem; border: 1px solid var(--color-border); background: rgba(255,255,255,0.85); overflow: hidden; }
+    .fund-card__transactions summary { padding: 0.75rem 1.1rem; display: flex; align-items: center; gap: 0.6rem; font-size: 0.9rem; font-weight: 600; color: var(--color-primary); cursor: pointer; background: rgba(77,177,200,0.08); }
+    .fund-card__transactions summary:hover { background: rgba(77,177,200,0.14); }
+
+    /* PATCH */
+    .pie-segment,
+    .pie-slice {
+        cursor: pointer;
+        transition: transform 0.25s ease, filter 0.25s ease;
+        transform-origin: 50px 50px;
+    }
+    .pie-segment:hover,
+    .pie-slice:hover {
+        transform: scale(1.05);
+        filter: drop-shadow(0 4px 8px rgba(13, 44, 84, 0.15));
+    }
+    .pie-segment:focus,
+    .pie-segment:focus-visible,
+    .pie-slice:focus,
+    .pie-slice:focus-visible { outline: none; }
+    .pie-segment:focus path,
+    .pie-segment:focus-visible path,
+    .pie-segment:focus circle,
+    .pie-segment:focus-visible circle,
+    .pie-slice:focus path,
+    .pie-slice:focus-visible path {
+        transform: scale(1.05);
+        filter: drop-shadow(0 4px 8px rgba(13, 44, 84, 0.18));
+    }
+    .line-chart-grid-line { stroke: #E5E8EE; stroke-dasharray: 2 3; }
+    .line-chart-axis-text { font-size: 12px; fill: var(--color-muted); }
+    .line-chart-dot { cursor: pointer; transition: r 0.2s; outline: none; }
+    .line-chart-dot:hover { r: 7; }
+    .line-chart-dot:focus-visible { r: 7; outline: 2px solid var(--color-accent); outline-offset: 2px; }
+
+    .text-positive { color: var(--color-accent); }
+    .text-negative { color: #B2403D; }
+    .muted { color: var(--color-muted); }
+
+    /* Export report styling */
+    .export-shell {
+        max-width: 1080px;
+        margin: 0 auto;
+        display: flex;
+        flex-direction: column;
+        gap: 3rem;
+        padding: 3.5rem 2rem 4rem;
+        background: linear-gradient(180deg, rgba(253,254,255,0.92) 0%, rgba(248,249,250,0.95) 100%);
+    }
+    .export-hero {
+        background: var(--color-card);
+        border-radius: 1.9rem;
+        border: 2px solid var(--color-primary);
+        padding: 3rem;
+        box-shadow: none;
+    }
+    .export-hero__layout {
+        display: grid;
+        gap: 2.5rem;
+    }
+    .export-hero__content {
+        display: flex;
+        flex-direction: column;
+        gap: 1.8rem;
+    }
+    .export-hero__features {
+        display: grid;
+        gap: 1rem;
+    }
+    .export-hero__features .feature-card { height: 100%; }
+    @media (min-width: 960px) {
+        .export-hero__layout { grid-template-columns: minmax(0, 1.15fr) minmax(0, 0.85fr); align-items: start; }
+    }
+    .export-hero__badge {
+        display: inline-flex;
+        align-items: center;
+        gap: 0.45rem;
+        padding: 0.55rem 1rem;
+        border-radius: 999px;
+        background: rgba(13,44,84,0.08);
+        color: var(--color-primary);
+        font-size: 0.8rem;
+        font-weight: 600;
+        letter-spacing: 0.1em;
+        text-transform: uppercase;
+    }
+    .export-hero__title { font-size: 3.1rem; font-weight: 700; color: var(--color-primary); letter-spacing: 0.08em; text-transform: uppercase; margin: 0; overflow-wrap: anywhere; }
+    .export-hero__lead { color: var(--color-text); line-height: 1.6; font-size: 1.1rem; margin: 0; }
+    .export-hero__meta { display: grid; gap: 1rem; grid-template-columns: repeat(auto-fit, minmax(190px, 1fr)); }
+    .export-hero__meta-item {
+        background: rgba(255,255,255,0.9);
+        border: 1px solid var(--color-border);
+        border-radius: 1.2rem;
+        padding: 1rem 1.2rem;
+        display: flex;
+        flex-direction: column;
+        gap: 0.45rem;
+    }
+    .meta-label { text-transform: uppercase; letter-spacing: 0.08em; font-size: 0.7rem; color: var(--color-muted); font-weight: 600; }
+    .meta-value { font-size: 1.1rem; font-weight: 600; color: var(--color-primary); }
+    .export-hero__disclaimer { font-size: 0.9rem; color: var(--color-muted); line-height: 1.6; margin: 0; }
+
+    .narrative { display: flex; flex-direction: column; gap: 1rem; background: var(--color-card); border-radius: 1.5rem; border: 1px solid var(--color-border); padding: 1.8rem 2.1rem; }
+    .narrative h2 { margin: 0; font-size: 1.35rem; font-weight: 600; color: var(--color-primary); }
+    .narrative p { margin: 0; font-size: 1rem; color: var(--color-text); }
+
+    .section-heading { display: flex; flex-direction: column; gap: 0.5rem; }
+    .section-heading .pill { align-self: flex-start; }
+    .section-heading h2 { margin: 0; font-size: 2rem; font-weight: 700; color: var(--color-primary); overflow-wrap: anywhere; }
+    .section-heading p { margin: 0; font-size: 1rem; color: var(--color-text); }
+    .section-meta { margin: 0; font-size: 0.85rem; color: var(--color-muted); font-weight: 500; text-transform: uppercase; letter-spacing: 0.08em; }
+
+    @media (min-width: 900px) {
+        .section-heading { display: grid; grid-template-columns: 1fr auto; align-items: end; gap: 0.5rem 1.25rem; }
+        .section-heading h2 { margin: 0; }
+        .section-heading .section-meta { align-self: center; justify-self: end; }
+        .section-heading .pill { grid-column: 1 / -1; }
+    }
+
+    .summary-grid { display: grid; gap: 1.2rem; grid-template-columns: repeat(auto-fit, minmax(220px, 1fr)); }
+    /* PATCH */
+    .summary-card { padding: 1.4rem 1.5rem; border-radius: 1.4rem; border: 1px solid var(--color-border); background: linear-gradient(180deg, rgba(77, 177, 200, 0.06), transparent 45%), var(--color-card); display: flex; flex-direction: column; justify-content: space-between; gap: 0.65rem; transition: transform 0.25s ease, box-shadow 0.25s ease, border-color 0.25s ease, background 0.25s ease; box-shadow: var(--color-shadow); }
+    /* PATCH */
+    .summary-card:hover { transform: translateY(-3px); border-color: var(--color-border-strong); box-shadow: var(--color-shadow-strong); background: linear-gradient(180deg, rgba(77, 177, 200, 0.1), transparent 55%), var(--color-card); }
+    .summary-label { text-transform: uppercase; letter-spacing: 0.08em; font-size: 0.7rem; color: var(--color-muted); font-weight: 600; }
+    /* PATCH: Summary values – keep large figures inside cards */
+    .summary-value {
+        font-size: clamp(1.4rem, 3.2vw, 2rem);
+        font-weight: 700;
+        color: var(--color-primary);
+        line-height: 1.05;
+        white-space: nowrap;
+        font-variant-numeric: tabular-nums;
+        font-feature-settings: "tnum" 1, "lnum" 1;
+    }
+    .summary-note { font-size: 0.9rem; color: var(--color-muted); margin: 0; }
+    .summary-warning { margin-bottom: 1rem; padding: 1rem 1.25rem; border-radius: 1rem; border: 1px solid rgba(220,53,69,0.25); background: rgba(220,53,69,0.08); color: #7f1d1d; font-size: 0.95rem; line-height: 1.5; }
+
+    .fund-export-grid { display: flex; flex-direction: column; gap: 1.65rem; }
+    .fund-export { background: var(--color-card); border-radius: 1.6rem; border: 1px solid var(--color-border); padding: 1.85rem; display: flex; flex-direction: column; gap: 1.4rem; }
+    .fund-export__header { display: grid; gap: 1.2rem; grid-template-columns: auto 1fr; align-items: center; }
+    .fund-export__title { display: flex; flex-direction: column; gap: 0.5rem; overflow-wrap: anywhere; }
+    .fund-export__meta { display: flex; flex-wrap: wrap; gap: 0.5rem; font-size: 0.85rem; color: var(--color-muted); }
+    .fund-export__meta span { padding: 0.4rem 0.7rem; border-radius: 999px; background: rgba(77,177,200,0.12); color: var(--color-primary); font-weight: 500; }
+    .fund-export__metrics { display: grid; grid-template-columns: repeat(auto-fit, minmax(170px, 1fr)); gap: 1rem; }
+    .fund-export__metric { background: rgba(77,177,200,0.08); border: 1px solid rgba(77,177,200,0.2); border-radius: 1.15rem; padding: 1rem 1.1rem; display: flex; flex-direction: column; gap: 0.5rem; }
+    .metric-label { font-size: 0.7rem; text-transform: uppercase; letter-spacing: 0.08em; color: var(--color-muted); font-weight: 600; }
+    .metric-value {
+        font-size: 1.25rem;
+        font-weight: 600;
+        color: var(--color-primary);
+        font-variant-numeric: tabular-nums;
+        font-feature-settings: "tnum" 1, "lnum" 1;
+        white-space: nowrap;
+    }
+    .metric-sub { font-size: 0.78rem; color: var(--color-muted); }
+
+    .fund-export__table-wrapper { overflow-x: auto; border-radius: 1.15rem; border: 1px solid var(--color-border); background: rgba(248,249,250,0.9); mask-image: linear-gradient(to right, transparent, #000 16px, #000 calc(100% - 16px), transparent); }
+    .fund-export__table { width: 100%; border-collapse: collapse; font-size: 0.9rem; }
+    .fund-export__table th,
+    .fund-export__table td { padding: 0.85rem 1rem; border-bottom: 1px solid rgba(234,236,238,0.7); }
+    .fund-export__table th { text-align: left; font-weight: 600; color: var(--color-muted); background: rgba(242,244,246,0.8); text-transform: uppercase; letter-spacing: 0.08em; font-size: 0.72rem; position: sticky; top: 0; z-index: 1; }
+    .fund-export__table th.text-right,
+    .fund-export__table td.text-right { text-align: right; }
+
+    .line-export { display: flex; flex-direction: column; gap: 1.35rem; border-radius: 1.55rem; padding: 2rem; background: var(--color-card); border: 1px solid var(--color-border); }
+    .line-canvas { border-radius: 1.25rem; overflow: hidden; background: #ffffff; border: 1px solid var(--color-border); }
+    .line-canvas svg { width: 100%; height: auto; display: block; }
+    .line-legend { display: flex; flex-wrap: wrap; gap: 0.6rem; align-items: center; }
+    .legend-pill { display: inline-flex; align-items: center; gap: 0.4rem; padding: 0.45rem 0.9rem; border-radius: 999px; font-size: 0.78rem; font-weight: 600; letter-spacing: 0.06em; text-transform: uppercase; border: 1px solid transparent; max-width: 100%; }
+    .legend-pill span, .legend-name { overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
+    .legend-pill:focus-visible { outline: 2px solid rgba(13,44,84,0.45); outline-offset: 3px; }
+    .legend-pill--base { background: rgba(51,55,61,0.1); color: var(--color-text); border-color: rgba(51,55,61,0.2); }
+    .legend-pill--value { background: rgba(77,177,200,0.18); color: var(--color-primary); border-color: rgba(77,177,200,0.35); }
+    .legend-pill--projection { background: rgba(13,44,84,0.1); color: var(--color-primary); border-color: rgba(13,44,84,0.25); }
+    .chart-footnote { margin: 0; font-size: 0.9rem; color: var(--color-muted); line-height: 1.6; }
+
+    .export-footer { margin-top: 2rem; text-align: center; font-size: 0.85rem; color: var(--color-muted); }
+    /* PATCH */
+    .footer-note { margin: 0; font-size: 0.85rem; color: var(--color-muted); }
+
+    @media (prefers-reduced-motion: reduce) {
+        * { transition: none !important; animation: none !important; }
+    }
+
+    @page { margin: 14mm; }
+
+    @media print {
+        body { background: #ffffff !important; }
+        .export-shell { background: #ffffff; padding: 0; }
+        .card { box-shadow: none !important; border-color: #d7dbe0; page-break-inside: avoid; break-inside: avoid; }
+        .summary-card, .fund-export, .line-export, .pie-export, .export-hero { page-break-inside: avoid; break-inside: avoid; }
+        #chart-tooltip { display: none !important; }
+    }
+
+    .pie-export { display: grid; gap: 1.6rem; grid-template-columns: repeat(auto-fit, minmax(230px, 1fr)); align-items: center; }
+    .pie-canvas { display: flex; justify-content: center; }
+    .pie-canvas svg { max-width: 320px; width: 100%; height: auto; }
+    .pie-legend { display: flex; flex-direction: column; gap: 0.85rem; }
+    .legend-item { display: flex; align-items: center; justify-content: space-between; gap: 0.85rem; font-size: 0.95rem; color: var(--color-text); padding: 0.7rem 1rem; border-radius: 0.9rem; background: var(--color-card); border: 1px solid var(--color-border); }
+    .legend-dot { width: 0.9rem; height: 0.9rem; border-radius: 999px; flex-shrink: 0; box-shadow: 0 0 0 3px rgba(13,44,84,0.1); }
+    .legend-name { flex: 1; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; font-weight: 500; }
+    .legend-value { font-weight: 600; color: var(--color-primary); }
+
+    .export-explanations { display: grid; gap: 1.3rem; grid-template-columns: repeat(auto-fit, minmax(250px, 1fr)); font-size: 0.96rem; color: var(--color-text); }
+    .export-explanations article { background: var(--color-card); border-radius: 1.3rem; border: 1px solid var(--color-border); padding: 1.45rem; display: flex; flex-direction: column; gap: 0.8rem; }
+    .export-explanations h3 { margin: 0; font-size: 1.1rem; font-weight: 600; color: var(--color-primary); }
+
+    .disclaimer-block { display: flex; flex-direction: column; gap: 0.9rem; background: rgba(255,255,255,0.95); border: 1px solid rgba(220,53,69,0.25); border-radius: 1.2rem; padding: 1.35rem 1.5rem; }
+    .disclaimer-title { font-size: 0.88rem; font-weight: 600; color: #b91c1c; text-transform: uppercase; letter-spacing: 0.08em; margin: 0; }
+    .disclaimer-list { list-style: none; padding: 0; margin: 0; display: flex; flex-direction: column; gap: 0.75rem; }
+    .disclaimer-item { display: flex; gap: 0.75rem; font-size: 0.9rem; color: var(--color-text); line-height: 1.6; }
+
+    @media (max-width: 768px) {
+        .report-header { padding: 3rem 1rem 2rem; }
+        .export-hero { padding: 2.2rem; }
+        h1.report-title { font-size: 2.6rem; }
+        h2.section-title { font-size: 1.9rem; }
+    }
+  </style>
+</head>
+<body class="antialiased text-body">
+  <header class="report-header">
+    <div class="report-header__inner">
+      <div class="brand-logo">Fair<span>Life</span></div>
+      <div class="hero-layout">
+        <div class="hero-intro">
+          <div class="hero-badges">
+            <span class="hero-badge">Report investičního portfolia</span>
+          </div>
+          <h1 class="report-title">Přehled vašeho finančního světa</h1>
+          <p>Sledujte výkonnost fondů, analyzujte cashflow a připravte pro klienty precizní výstupy v jednom elegantním prostředí.</p>
+          <div class="hero-disclaimer">
+            <span>© <span id="current-year"></span> Ondřej Lacina</span>
+            <span>Toto dílo je chráněno autorským právem dle zákona č. 121/2000 Sb.</span>
+            <span>Šíření mimo strukturu Fair-life je zakázáno.</span>
+          </div>
+        </div>
+        <div class="feature-stack">
+            <div class="feature-card benefit">
+              <div class="feature-text">
+                <span class="feature-title benefit-title">Interaktivní řízení</span>
+                <span class="feature-desc benefit-desc">Import, export i validace dat v reálném čase na jednom místě.</span>
+              </div>
+            </div>
+            <div class="feature-card benefit">
+              <div class="feature-text">
+                <span class="feature-title benefit-title">Pokročilé analýzy</span>
+                <span class="feature-desc benefit-desc">XIRR, projekce výnosů i vizualizace portfolia bez nutnosti dalších nástrojů.</span>
+              </div>
+            </div>
+        </div>
+      </div>
+    </div>
+  </header>
+
+  <!-- Tooltip for charts -->
+  <div id="chart-tooltip" class="hidden"></div>
+
+  <!-- Toast container for notifications -->
+  <div id="toast-container"></div>
+
+  <main class="relative px-4 sm:px-6 lg:px-8 py-12">
+    <div class="max-w-7xl mx-auto space-y-12">
+
+      <!-- === SELF-TESTS & STATUS NOTIFICATIONS === -->
+      <div id="status-container" class="space-y-4"></div>
+
+      <!-- === FX & OUTPUT CONTROLS === -->
+      <div class="grid gap-6 xl:grid-cols-3">
+        <section class="card p-6 sm:p-7 xl:col-span-2">
+          <div class="flex flex-col sm:flex-row sm:items-center sm:justify-between gap-6">
+            <div class="space-y-2">
+              <h2 class="section-title">Nastavení měny</h2>
+              <p class="text-sm text-muted">Zadejte kurz EUR/CZK a zvolte výstupní měnu reportu.</p>
+            </div>
+            <div class="flex items-center gap-4 flex-wrap">
+              <label class="flex flex-col sm:flex-row sm:items-center gap-2 text-sm text-body">
+                <span class="font-medium text-primary whitespace-nowrap">Kurz (CZK za 1 EUR)</span>
+                <input id="fx-rate" type="number" step="0.0001" placeholder="např. 25.30" class="glass-input px-3 py-2 rounded-xl border w-[170px] tabular text-right text-primary placeholder:text-muted" />
+              </label>
+              <div class="hidden sm:block w-px h-9 bg-divider"></div>
+              <label class="flex flex-col sm:flex-row sm:items-center gap-2 text-sm text-body">
+                <span class="font-medium text-primary">Výstup v měně</span>
+                <select id="out-curr" class="glass-input px-3 py-2 rounded-xl border bg-white text-primary">
+                  <option value="CZK" selected>CZK</option>
+                  <option value="EUR">EUR</option>
+                </select>
+              </label>
+            </div>
+          </div>
+        </section>
+
+        <!-- === DATA MANAGEMENT === -->
+        <section class="card p-6 sm:p-7">
+          <div class="space-y-5">
+            <div class="space-y-2">
+              <h3 class="card-subtitle">Správa dat</h3>
+              <p class="text-sm text-muted">Synchronizujte portfolio jedním kliknutím.</p>
+            </div>
+            <div class="flex flex-col gap-3 text-sm">
+              <label class="flex flex-col sm:flex-row sm:items-center gap-2">
+                <span class="font-medium text-primary whitespace-nowrap">Jméno a příjmení klienta (1. pád)</span>
+                <input id="client-name" type="text" placeholder="např. Jan Novák" class="glass-input px-3 py-2 rounded-xl border w-full sm:w-[260px] text-primary placeholder:text-muted" />
+              </label>
+              <label class="flex flex-col gap-1">
+                <span class="font-medium text-primary">Oslovení klienta (5. pád)</span>
+                <input id="client-salutation" type="text" placeholder="např. Pepo" class="glass-input px-3 py-2 rounded-xl border w-full sm:w-[260px] text-primary placeholder:text-muted" />
+                <span class="text-xs text-muted">Tip: Pepo, Jano, paní Nováková…</span>
+              </label>
+              <!-- /* PATCH */ Pohlaví klienta -->
+              <div class="flex flex-col gap-2 text-sm text-body">
+                <span class="font-medium text-primary">Pohlaví klienta</span>
+                <div class="flex flex-wrap items-center gap-4">
+                  <label class="inline-flex items-center gap-2">
+                    <input id="client-gender-male" type="radio" name="client-gender" value="male" class="form-radio" />
+                    <span>Muž</span>
+                  </label>
+                  <label class="inline-flex items-center gap-2">
+                    <input id="client-gender-female" type="radio" name="client-gender" value="female" class="form-radio" />
+                    <span>Žena</span>
+                  </label>
+                </div>
+              </div>
+              <div class="flex flex-col gap-2 text-sm text-body">
+                <span class="font-medium text-primary">Forma komunikace v reportu</span>
+                <div class="flex flex-wrap items-center gap-4">
+                  <label class="inline-flex items-center gap-2">
+                    <input id="client-tone-vykani" type="radio" name="client-tone" value="vykani" class="form-radio" />
+                    <span>Vykání</span>
+                  </label>
+                  <label class="inline-flex items-center gap-2">
+                    <input id="client-tone-tykani" type="radio" name="client-tone" value="tykani" class="form-radio" />
+                    <span>Tykání</span>
+                  </label>
+                </div>
+              </div>
+              <!-- /* PATCH */ Jazyk reportu -->
+              <div class="flex flex-col gap-2 text-sm text-body">
+                <span class="font-medium text-primary">Jazyk reportu</span>
+                <div class="flex flex-wrap items-center gap-4">
+                  <label class="inline-flex items-center gap-2">
+                    <input id="client-language-cs" type="radio" name="client-language" value="cs" class="form-radio" />
+                    <span>Čeština</span>
+                  </label>
+                  <label class="inline-flex items-center gap-2">
+                    <input id="client-language-en" type="radio" name="client-language" value="en" class="form-radio" />
+                    <span>English</span>
+                  </label>
+                </div>
+              </div>
+              <div class="flex flex-wrap gap-2">
+                <button data-action="export-json" type="button" class="secondary-btn px-4 py-2 rounded-xl text-sm font-medium">Exportovat do .json</button>
+                <button data-action="import-json" type="button" class="secondary-btn px-4 py-2 rounded-xl text-sm font-medium">Importovat z .json</button>
+                <button data-action="export-html" type="button" class="primary-btn px-4 py-2 rounded-xl text-sm font-medium flex items-center gap-2">
+                  <svg class="h-4 w-4" viewBox="0 0 20 20" fill="none" xmlns="http://www.w3.org/2000/svg">
+                    <path d="M4 10.5l6 6 6-6" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"/>
+                    <path d="M10 3.5v12" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"/>
+                  </svg>
+                  Exportovat report pro klienta (.html)
+                </button>
+                <input type="file" id="import-file-input" class="hidden" accept=".json">
+              </div>
+              <div id="last-saved-indicator" class="text-xs text-muted sm:ml-auto"></div>
+            </div>
+          </div>
+        </section>
+      </div>
+
+      <div class="divider"></div>
+
+      <!-- === INPUT SECTIONS (PROVIDERS) === -->
+      <section class="space-y-6">
+        <div class="space-y-3">
+          <span class="pill">Vstupní data</span>
+          <div class="space-y-2">
+            <h2 class="section-title">Správa poskytovatelů a transakcí</h2>
+            <p class="text-sm text-body max-w-3xl">Importujte nebo přepisujte data jednotlivých platforem, kontrolujte jejich konzistenci a sledujte výsledky okamžitě po zadání.</p>
+          </div>
+        </div>
+        <div id="provider-sections" class="flex flex-col gap-6"></div>
+      </section>
+
+      <div class="divider"></div>
+      
+      <!-- === RESULTS BY FUND (REDESIGNED) === -->
+      <section class="card p-7 sm:p-8">
+        <div class="flex flex-col md:flex-row md:items-center md:justify-between gap-4">
+          <div>
+            <h2 class="section-title">Výsledky po fondech</h2>
+            <p class="text-sm text-muted">Detailní rozpad portfolia včetně XIRR pro jednotlivé fondy.</p>
+          </div>
+          <div id="amount-note-funds" class="text-xs font-medium uppercase tracking-[0.2em] text-muted">Částky v CZK</div>
+        </div>
+        <div id="funds-by-card-container" class="space-y-4">
+        </div>
+      </section>
+
+      <!-- === PORTFOLIO SUMMARY === -->
+      <section class="card p-7 sm:p-8">
+        <div class="flex flex-col md:flex-row md:items-center md:justify-between gap-4">
+          <div>
+            <h2 class="section-title">Souhrn Vašeho portfolia</h2>
+            <p class="text-sm text-muted">Klíčové ukazatele, které Vám v kostce ukážou celkové zdraví a výkon Vašich investic.</p>
+          </div>
+          <div id="amount-note-portfolio" class="text-xs font-medium uppercase tracking-[0.2em] text-muted">Částky v CZK</div>
+        </div>
+        <div id="portfolio-summary-content" class="text-sm">
+        </div>
+      </section>
+
+      <!-- === CHARTS & VISUALIZATIONS === -->
+      <section id="charts-section" class="space-y-8">
+        <div id="line-chart-card" class="card p-7 sm:p-8" style="display: none;">
+          <div class="flex flex-col gap-2 sm:flex-row sm:items-center sm:justify-between">
+            <h2 class="section-title">Vývoj hodnoty portfolia s predikcí do roku 2035</h2>
+            <p class="text-sm text-muted max-w-md">Simulace navazuje na aktuální XIRR a ukazuje odhad dalšího růstu při zachování tempa.</p>
+          </div>
+          <div id="line-chart-container" class="relative mt-6"></div>
+        </div>
+        <div id="pie-chart-card" class="card p-7 sm:p-8" style="display: none;">
+          <div class="flex flex-col gap-2 sm:flex-row sm:items-center sm:justify-between">
+            <h2 class="section-title">Alokace portfolia v čase</h2>
+            <p class="text-sm text-muted max-w-md">Prozkoumejte rozložení kapitálu v jednotlivých fondech k libovolnému datu.</p>
+          </div>
+          <div id="pie-chart-container" class="max-w-xl w-full mx-auto mt-6"></div>
+           <div class="mt-6">
+               <input type="range" id="pie-time-slider" class="w-full">
+               <div class="flex justify-between text-xs text-muted mt-2">
+                   <span id="slider-start-date-label"></span>
+                   <span id="slider-current-date-label" class="font-semibold text-accent"></span>
+                   <span id="slider-end-date-label"></span>
+               </div>
+          </div>
+        </div>
+      </section>
+
+      <!-- === ANNUITY CALCULATOR === -->
+      <section id="annuity-calculator-section" class="card p-7 sm:p-8">
+        <div class="flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
+          <div>
+            <h2 class="section-title">Kalkulačka nekonečné renty</h2>
+            <p class="text-sm text-muted">Zjistěte, jak velký kapitál je potřeba pro pasivní příjem z portfolia.</p>
+          </div>
+        </div>
+        <div class="mt-5 flex items-center gap-4 flex-wrap">
+            <label class="flex flex-col sm:flex-row sm:items-center gap-2">
+                <span class="text-sm font-medium text-primary whitespace-nowrap">Požadovaná měsíční renta</span>
+                <input id="annuity-input" type="text" placeholder="např. 10 000" class="glass-input px-3 py-2 rounded-xl border w-[200px] tabular text-right text-primary placeholder:text-muted" />
+            </label>
+            <div id="annuity-annual-equivalent" class="text-sm text-muted"></div>
+        </div>
+        <div id="annuity-result" class="mt-5 text-sm text-primary bg-accent-soft border border-accent-soft rounded-xl p-5" style="display: none;"></div>
+        <p id="annuity-disclaimer" class="mt-3 text-xs text-muted italic" style="display: none;">
+          *Tento výpočet předpokládá, že si z portfolia každý rok vyberete pouze vygenerovaný výnos (zhodnocení) a jistina zůstane nedotčena, aby mohla generovat další výnos v následujícím roce.
+        </p>
+      </section>
+
+      <!-- === EXPLANATIONS === -->
+      <section id="explanations-section" class="card p-7 sm:p-8">
+        <details class="group">
+          <summary class="text-lg font-semibold cursor-pointer flex items-center justify-between text-primary">
+            <span>Vysvětlivky a použité metriky</span>
+            <svg class="summary-arrow w-5 h-5 transition-transform group-open:rotate-90 text-muted" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20" fill="currentColor">
+              <path fill-rule="evenodd" d="M7.21 14.77a.75.75 0 01.02-1.06L11.168 10 7.23 6.29a.75.75 0 111.04-1.08l4.5 4.25a.75.75 0 010 1.08l-4.5 4.25a.75.75 0 01-1.06-.02z" clip-rule="evenodd" />
+            </svg>
+          </summary>
+          <div class="mt-4 pt-4 border-t border-subtle text-sm text-body space-y-5">
+            <div>
+              <h4 class="font-semibold text-primary">Co je to XIRR a jak funguje?</h4>
+               <p class="mt-2 leading-relaxed">
+                Jde o klíčový ukazatel reálné výkonnosti Vašeho portfolia. Na rozdíl od jednoduchého průměru totiž XIRR spravedlivě zohledňuje, <strong>kdy a jaké částky</strong> jste do portfolia vkládal. Výsledné procento Vám tak dává přesný obraz o tom, jak efektivně Vaše peníze v průměru každý rok pracovaly.
+              </p>
+            </div>
+             <div class="pt-4 border-t border-subtle">
+              <h4 class="font-semibold text-primary">Co je kumulativní zhodnocení?</h4>
+               <p class="mt-2 leading-relaxed">
+                Tento údaj Vám poskytuje rychlý a celkový pohled na dosavadní úspěšnost portfolia. Jednoduše řečeno, vyjadřuje Váš <strong>celkový čistý výnos jako procento ze všech Vašich vkladů</strong>. Je to souhrnné číslo, které ukazuje celkový růst od začátku investování až po dnešek.
+              </p>
+            </div>
+          </div>
+        </details>
+      </section>
+
+    </div>
+  </main>
+
+<script>
+document.addEventListener('DOMContentLoaded', () => {
+
+  const state = {
+      rows: { avant: [], codya: [], atris: [], jt: [] },
+      lastProcessedData: { funds: [], activeFunds: [], hasMixedCurrencies: false, portfolioSummary: {} },
+      fundColorMap: {},
+      clientName: '',
+      clientSalutation: '',
+      clientTone: 'vykani',
+      /* PATCH */ clientGender: 'male',
+      /* PATCH */ clientLanguage: 'cs'
+  };
+  const elements = {};
+  const updateToneInputs = () => {
+      if (!Array.isArray(elements.clientToneInputs)) return;
+      elements.clientToneInputs.forEach((input) => {
+          input.checked = input.value === state.clientTone;
+      });
+  };
+  /* PATCH */
+  const updateGenderInputs = () => {
+      if (!Array.isArray(elements.clientGenderInputs)) return;
+      elements.clientGenderInputs.forEach((input) => {
+          input.checked = input.value === state.clientGender;
+      });
+  };
+  /* PATCH */
+  const updateLanguageInputs = () => {
+      if (!Array.isArray(elements.clientLanguageInputs)) return;
+      elements.clientLanguageInputs.forEach((input) => {
+          input.checked = input.value === state.clientLanguage;
+      });
+  };
+  let rowSeq = 0;
+  let rafId = 0;
+
+  const PROVIDERS = { avant: 'AVANT', codya: 'CODYA', atris: 'ATRIS', jt: 'J&T' };
+  const CHART_COLORS = [
+      '#0d2c54', '#4DB1C8', '#6E7DA2', '#A4C4BC', '#F2D7B6', '#8FA6BF', '#C8D8E4', '#E0A899'
+  ];
+  const SCRIPT_CLOSE_TAG = '<' + '/script>';
+  const MS_PER_DAY = 24 * 60 * 60 * 1000;
+  const PROJECTION_END_YEAR = 2035;
+  const getColor = (fundName) => {
+      if (!state.fundColorMap[fundName]) {
+          const colorIndex = Object.keys(state.fundColorMap).length % CHART_COLORS.length;
+          state.fundColorMap[fundName] = CHART_COLORS[colorIndex];
+      }
+      return state.fundColorMap[fundName];
+  };
+  const getFundInitials = (name) => {
+      return name
+        .split(/\s+/)
+        .filter(Boolean)
+        .slice(0, 2)
+        .map(part => part.charAt(0).toUpperCase())
+        .join('') || 'FL';
+  };
+  
+  const htmlEscape = (value) => String(value ?? '').replace(/[&<>'"]/g, (char) => ({ '&': '&amp;', '<': '&lt;', '>': '&gt;', '"': '&quot;', "'": '&#39;' }[char]));
+  const utils = {
+    nf: (d = 2, opts = {}) => new Intl.NumberFormat('cs-CZ', { minimumFractionDigits: d, maximumFractionDigits: d, ...opts }),
+    toDate: (s) => { if (!s) return null; const t = String(s).trim(); if (/^\d{4}-\d{2}-\d{2}$/.test(t)) { const d = new Date(t); return isNaN(d.getTime()) ? null : d; } const m = t.match(/^([0-3]?\d)\.?\s*([01]?\d)\.?\s*(\d{4})$/); if (m) { const d = new Date(`${m[3]}-${m[2]}-${m[1]}`); return isNaN(d.getTime()) ? null : d; } const genericDate = new Date(t); return isNaN(genericDate.getTime()) ? null : genericDate; },
+    monthsDiff: (d1, d2) => { if (!(d1 instanceof Date && d2 instanceof Date && !isNaN(d1) && !isNaN(d2))) return NaN; const days = (d2.getTime() - d1.getTime()) / MS_PER_DAY; return Math.max(0, days / (365.2425 / 12)); },
+    numCZ: (v) => { if (v === null || v === undefined) return NaN; let t = String(v).replace(/\u00A0/g, ' ').trim(); if (t === '') return NaN; t = t.replace(/\s*\b(Kč|CZK|€|EUR)\b\s*/gi, ''); t = t.replace(/[\u2212\u2013\u2014]/g, '-'); let isNegative = false; if (t.startsWith('(') && t.endsWith(')')) { isNegative = true; t = t.substring(1, t.length - 1); } t = t.replace(/\s/g, ''); const lastComma = t.lastIndexOf(','); const lastDot = t.lastIndexOf('.'); if (lastComma > lastDot) { t = t.replace(/\./g, '').replace(',', '.'); } else if (lastDot > -1 && t.length - lastDot - 1 > 2) { t = t.replace(/,/g, ''); } else { t = t.replace(/,/g, ''); } const num = parseFloat(t); if (isNaN(num)) return NaN; return isNegative ? -Math.abs(num) : num; },
+    normName: s => String(s || '').replace(/[\u00A0\s]+/g, ' ').trim(),
+    convertAmount: (amt, from, to, fxRate) => { if (!isFinite(amt)) return NaN; if (from === to) return amt; const k = fxRate; if (!isFinite(k) || k <= 0) return NaN; if (from === 'EUR' && to === 'CZK') return amt * k; if (from === 'CZK' && to === 'EUR') return amt / k; return NaN; }
+  };
+  const formatDate = (date) => (date instanceof Date && !isNaN(date)) ? date.toLocaleDateString('cs-CZ') : '—';
+
+  const fmt2 = utils.nf(2); const fmt4 = utils.nf(4); const fmt1 = utils.nf(1); const fmt0 = utils.nf(0);
+  const cellNum = (v, d = 2) => { if(!isFinite(v)) return '—'; if(d === 4) return fmt4.format(v); if(d === 1) return fmt1.format(v); if(d === 0) return fmt0.format(v); return fmt2.format(v); };
+  const cellPct = v => isFinite(v) ? fmt2.format(v * 100) + '\u202F%' : '—';
+  /* PATCH: helpers – JEN formátování výstupu, ne výpočty */
+  const fmtInt = new Intl.NumberFormat('cs-CZ', { maximumFractionDigits: 0 });
+  /* PATCH: helpers – JEN formátování výstupu, ne výpočty */
+  const fmt1Decimal = new Intl.NumberFormat('cs-CZ', { minimumFractionDigits: 1, maximumFractionDigits: 1 });
+  /* PATCH: helpers – JEN formátování výstupu, ne výpočty */
+  const formatCurrency0 = (value, currency = 'CZK', { withUnit = false, locale = 'cs-CZ' } = {}) => {
+    if (!isFinite(value)) return '—';
+    const formatter = locale === 'cs-CZ' ? fmtInt : new Intl.NumberFormat(locale, { maximumFractionDigits: 0 });
+    const base = formatter.format(Math.round(value));
+    return withUnit ? `${base}\u00A0${currency}` : base;
+  };
+  /* PATCH: helpers – JEN formátování výstupu, ne výpočty */
+  const formatPercent1 = (value, { locale = 'cs-CZ' } = {}) => {
+      if (!isFinite(value)) return '—';
+      const perc = Math.round(value * 1000) / 10;
+      const formatter = locale === 'cs-CZ' ? fmt1Decimal : new Intl.NumberFormat(locale, { minimumFractionDigits: 1, maximumFractionDigits: 1 });
+      return formatter.format(perc) + '\u202F%';
+  };
+  /* PATCH: helpers – JEN formátování výstupu, ne výpočty */
+  const formatXirr1 = (value, options = {}) => {
+      const base = formatPercent1(value, options);
+      return base === '—' ? base : base + '\u00A0p.a.';
+  };
+  /* PATCH: helpers – JEN formátování výstupu, ne výpočty */
+  const formatMonths0 = (value, { locale = 'cs-CZ', language = 'cs' } = {}) => {
+      if (!isFinite(value)) return '—';
+      const formatter = locale === 'cs-CZ' ? fmtInt : new Intl.NumberFormat(locale, { maximumFractionDigits: 0 });
+      const suffix = language === 'en' ? 'months' : 'měs.';
+      return formatter.format(Math.round(value)) + '\u00A0' + suffix;
+  };
+  /* PATCH: pomocná funkce pro zobrazení kurzu */
+  const formatFxRate = (value) => {
+      if (!isFinite(value)) return '—';
+      return new Intl.NumberFormat('cs-CZ', { minimumFractionDigits: 4, maximumFractionDigits: 4 }).format(value);
+  };
+  /* PATCH */
+  const formatDateByLanguage = (date, language = 'cs') => {
+      if (!(date instanceof Date) || isNaN(date)) return '—';
+      const locale = language === 'en' ? 'en-GB' : 'cs-CZ';
+      return date.toLocaleDateString(locale);
+  };
+  const parseClientName = (fullName = '') => {
+      const parts = fullName.trim().split(/\s+/).filter(Boolean);
+      if (!parts.length) {
+          return { firstName: '', lastName: '' };
+      }
+      if (parts.length === 1) {
+          return { firstName: parts[0], lastName: '' };
+      }
+      return { firstName: parts[0], lastName: parts[parts.length - 1] };
+  };
+  const toVocative = (name = '') => {
+      const trimmed = name.trim();
+      if (!trimmed) return '';
+      const lower = trimmed.toLocaleLowerCase('cs-CZ');
+      const overrides = {
+          'pepa': 'pepo',
+          'jan': 'jane',
+          'honza': 'honzo',
+          'pavel': 'pavle',
+          'ondřej': 'ondřeji',
+          'lukáš': 'lukáši',
+          'tomáš': 'tomáši',
+          'jiří': 'jiří',
+          'karel': 'karle',
+          'martin': 'martine',
+          'michal': 'michale',
+          'radek': 'radku',
+          'marek': 'marku',
+          'adam': 'adame',
+          'alena': 'aleno',
+          'jana': 'jano',
+          'eva': 'evo',
+          'lenka': 'lenko',
+          'petra': 'petro',
+          'veronika': 'veroniko'
+      };
+      const override = overrides[lower];
+      if (override) {
+          return override.charAt(0).toLocaleUpperCase('cs-CZ') + override.slice(1);
+      }
+      const applyCasing = (base) => {
+          if (!base) return '';
+          const first = trimmed.charAt(0);
+          const rest = base.slice(1);
+          const firstConverted = base.charAt(0).toLocaleUpperCase('cs-CZ');
+          return first === first.toLocaleUpperCase('cs-CZ')
+              ? firstConverted + rest
+              : base.toLocaleLowerCase('cs-CZ');
+      };
+      const replaceEnding = (replacement) => applyCasing(replacement);
+      if (lower.endsWith('a')) {
+          return replaceEnding(lower.slice(0, -1) + 'o');
+      }
+      if (lower.endsWith('ek')) {
+          return replaceEnding(lower.slice(0, -2) + 'ku');
+      }
+      if (lower.endsWith('el')) {
+          return replaceEnding(lower.slice(0, -2) + 'le');
+      }
+      if (lower.endsWith('er')) {
+          return replaceEnding(lower.slice(0, -2) + 'ře');
+      }
+      if (lower.endsWith('as')) {
+          return replaceEnding(lower + 'i');
+      }
+      if (lower.endsWith('áš')) {
+          return replaceEnding(lower + 'i');
+      }
+      if (lower.endsWith('us')) {
+          return replaceEnding(lower.slice(0, -2) + 'e');
+      }
+      if (lower.endsWith('k')) {
+          return replaceEnding(lower + 'u');
+      }
+      if (lower.endsWith('o')) {
+          return replaceEnding(lower + 'u');
+      }
+      return replaceEnding(lower + 'e');
+  };
+  /* PATCH */
+  const formatSalutation = ({ firstName = '', lastName = '', tone = 'vykani', manualSalutation = '', gender = 'male', /* PATCH */ language = 'cs' }) => {
+      const manual = manualSalutation.trim();
+      if (manual) return manual;
+      const first = firstName.trim();
+      const last = lastName.trim();
+      const isFemale = gender === 'female';
+      /* PATCH */
+      if (language === 'en') {
+          if (first) {
+              return first;
+          }
+          if (last) {
+              return isFemale ? `Ms. ${last}` : `Mr. ${last}`;
+          }
+          return 'there';
+      }
+      if (tone === 'vykani') {
+          if (last) {
+              if (isFemale) {
+                  return `paní ${last}`;
+              }
+              if (/ová$/i.test(last)) {
+                  return `paní ${last}`;
+              }
+              return `pane ${toVocative(last) || last}`;
+          }
+          if (first) {
+              if (isFemale) {
+                  return `paní ${first}`;
+              }
+              return `pane ${toVocative(first) || first}`;
+          }
+          return isFemale ? 'Vážená klientko' : 'Vážený kliente';
+      }
+      if (first) {
+          return toVocative(first) || first;
+      }
+      if (last) {
+          if (isFemale) {
+              return last;
+          }
+          return toVocative(last) || last;
+      }
+      return isFemale ? 'milá klientko' : 'milý kliente';
+  };
+  
+  const finance = (() => {
+    function xnpv(rate, cfs) { if (!isFinite(rate)) return NaN; const sortedCfs = cfs.slice().sort((a, b) => a.date - b.date); const t0 = sortedCfs[0]?.date; if (!t0) return NaN; return sortedCfs.reduce((sum, cf) => { const days = (cf.date - t0) / 86400000; return sum + cf.amount / Math.pow(1 + rate, days / 365.25); }, 0); }
+    function xirr(cfs, iterations = 100) { if (!Array.isArray(cfs) || cfs.length < 2) return NaN; let hasPos = false, hasNeg = false; for (const cf of cfs) { if (cf.amount > 0) hasPos = true; if (cf.amount < 0) hasNeg = true; } if (!hasPos || !hasNeg) return NaN; let low = -0.9999, high = 10.0; let mid; for (let i = 0; i < iterations; i++) { mid = (low + high) / 2; const npv = xnpv(mid, cfs); if (Math.abs(npv) < 1e-6) break; if (npv > 0) { low = mid; } else { high = mid; } } return isFinite(mid) ? mid : NaN; }
+    return { xnpv, xirr };
+  })();
+  
+  const scheduleRecalc = () => { cancelAnimationFrame(rafId); rafId = requestAnimationFrame(recalculateAndRender); };
+  const showToast = (message, type = 'success') => {
+      const container = elements.toastContainer || document.getElementById('toast-container');
+      if (!container) return;
+      const toast = document.createElement('div');
+      toast.className = `toast toast-${type}`;
+      toast.innerHTML = `<svg class="w-6 h-6 mr-3" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor">${type === 'success' ? `<path stroke-linecap="round" stroke-linejoin="round" d="M9 12.75L11.25 15 15 9.75M21 12a9 9 0 11-18 0 9 9 0 0118 0z" />` : `<path stroke-linecap="round" stroke-linejoin="round" d="M12 9v3.75m-9.303 3.376c-.866 1.5.217 3.374 1.948 3.374h14.71c1.73 0 2.813-1.874 1.948-3.374L13.949 3.378c-.866-1.5-3.032-1.5-3.898 0L2.697 16.126zM12 15.75h.007v.008H12v-.008z" />`}</svg><span>${message}</span>`;
+      container.appendChild(toast);
+      requestAnimationFrame(() => {
+          toast.classList.add('show');
+      });
+      setTimeout(() => {
+          toast.classList.remove('show');
+          toast.addEventListener('transitionend', () => toast.remove());
+      }, 3000);
+  };
+
+  const saveState = () => {
+      try {
+          localStorage.setItem('investmentCalculatorState', JSON.stringify({ rows: state.rows, clientName: state.clientName, clientSalutation: state.clientSalutation, clientTone: state.clientTone, /* PATCH */ clientGender: state.clientGender, /* PATCH */ clientLanguage: state.clientLanguage }));
+          if (elements.lastSavedIndicator) {
+              elements.lastSavedIndicator.textContent = `Uloženo v ${new Date().toLocaleTimeString('cs-CZ')}`;
+          }
+      } catch (e) {
+          console.error("Failed to save state:", e);
+          showToast("Chyba při ukládání dat.", 'error');
+      }
+  };
+  /* PATCH */
+  const loadState = () => {
+      try {
+          const savedStateJSON = localStorage.getItem('investmentCalculatorState');
+          if (savedStateJSON) {
+              const savedState = JSON.parse(savedStateJSON);
+              if (savedState && typeof savedState.rows === 'object') {
+                  Object.keys(PROVIDERS).forEach(key => {
+                      const sourceRows = Array.isArray(savedState.rows[key]) ? savedState.rows[key] : [];
+                      state.rows[key] = sourceRows.map(row => ({ ...row, freeze: !!row.freeze }));
+                  });
+                  state.clientName = typeof savedState.clientName === 'string' ? savedState.clientName : '';
+                  state.clientSalutation = typeof savedState.clientSalutation === 'string' ? savedState.clientSalutation : '';
+                  state.clientTone = typeof savedState.clientTone === 'string' && savedState.clientTone === 'tykani' ? 'tykani' : 'vykani';
+                  if (Object.prototype.hasOwnProperty.call(savedState, 'clientPreferVykanie')) {
+                      state.clientTone = savedState.clientPreferVykanie ? 'vykani' : 'tykani';
+                  }
+                  state.clientGender = typeof savedState.clientGender === 'string' && savedState.clientGender === 'female' ? 'female' : 'male';
+                  state.clientLanguage = typeof savedState.clientLanguage === 'string' && savedState.clientLanguage === 'en' ? 'en' : 'cs';
+                  const allIds = Object.values(state.rows).flat().map(r => r.id);
+                  rowSeq = allIds.length > 0 ? Math.max(...allIds) : 0;
+                  showToast('Data byla úspěšně načtena z prohlížeče.');
+              }
+          }
+      } catch (e) {
+          console.error('Failed to load state:', e);
+          showToast('Nepodařilo se načíst uložená data.', 'error');
+      }
+      renderAllInputs();
+      if (elements.clientNameInput) {
+          elements.clientNameInput.value = state.clientName;
+      }
+      if (elements.clientSalutationInput) {
+          elements.clientSalutationInput.value = state.clientSalutation;
+      }
+      updateGenderInputs();
+      updateToneInputs();
+      updateLanguageInputs();
+      scheduleRecalc();
+  };
+  /* PATCH */
+  const exportState = () => {
+      const payload = {
+          rows: state.rows,
+          clientName: state.clientName,
+          clientSalutation: state.clientSalutation,
+          clientTone: state.clientTone,
+          clientGender: state.clientGender,
+          clientLanguage: state.clientLanguage
+      };
+      const stateString = JSON.stringify(payload, null, 2);
+      const blob = new Blob([stateString], { type: 'application/json' });
+      const url = URL.createObjectURL(blob);
+      const a = document.createElement('a');
+      a.href = url;
+      a.download = `portfolio-export-${new Date().toISOString().split('T')[0]}.json`;
+      document.body.appendChild(a);
+      a.click();
+      document.body.removeChild(a);
+      URL.revokeObjectURL(url);
+      showToast('Data byla úspěšně exportována.');
+  };
+  const importState = (file) => {
+      if (!file) return;
+      const reader = new FileReader();
+      reader.onload = (e) => {
+          try {
+              const importedState = JSON.parse(e.target.result);
+              if (importedState && typeof importedState.rows === 'object') {
+                  Object.keys(PROVIDERS).forEach(key => {
+                      const sourceRows = Array.isArray(importedState.rows[key]) ? importedState.rows[key] : [];
+                      state.rows[key] = sourceRows.map(row => ({ ...row, freeze: !!row.freeze }));
+                  });
+                  state.clientName = typeof importedState.clientName === 'string' ? importedState.clientName : '';
+                  state.clientSalutation = typeof importedState.clientSalutation === 'string' ? importedState.clientSalutation : '';
+                  if (typeof importedState.clientTone === 'string') {
+                      state.clientTone = importedState.clientTone === 'tykani' ? 'tykani' : 'vykani';
+                  } else if (Object.prototype.hasOwnProperty.call(importedState, 'clientPreferVykanie')) {
+                      state.clientTone = importedState.clientPreferVykanie ? 'vykani' : 'tykani';
+                  } else {
+                      state.clientTone = 'vykani';
+                  }
+                  /* PATCH */
+                  if (typeof importedState.clientGender === 'string') {
+                      state.clientGender = importedState.clientGender === 'female' ? 'female' : 'male';
+                  } else if (typeof importedState.clientIsFemale === 'boolean') {
+                      state.clientGender = importedState.clientIsFemale ? 'female' : 'male';
+                  } else {
+                      state.clientGender = 'male';
+                  }
+                  /* PATCH */
+                  if (typeof importedState.clientLanguage === 'string') {
+                      state.clientLanguage = importedState.clientLanguage === 'en' ? 'en' : 'cs';
+                  } else {
+                      state.clientLanguage = 'cs';
+                  }
+                  const allIds = Object.values(state.rows).flat().map(r => r.id);
+                  rowSeq = allIds.length > 0 ? Math.max(...allIds) : 0;
+                  if (elements.clientNameInput) {
+                      elements.clientNameInput.value = state.clientName;
+                  }
+                  if (elements.clientSalutationInput) {
+                      elements.clientSalutationInput.value = state.clientSalutation;
+                  }
+                  updateGenderInputs();
+                  updateToneInputs();
+                  /* PATCH */
+                  updateLanguageInputs();
+                  saveState();
+                  renderAllInputs();
+                  scheduleRecalc();
+                  showToast("Data byla úspěšně importována.");
+              } else {
+                  throw new Error("Invalid file structure.");
+              }
+          } catch (err) {
+              console.error("Failed to import state:", err);
+              showToast("Chyba při importu: neplatný formát souboru.", 'error');
+          }
+      };
+      reader.readAsText(file);
+  };
+
+  const createProviderSection = (providerKey) => {
+      const providerName = PROVIDERS[providerKey];
+      const isAtris = providerKey === 'atris';
+      let specialTooltip = '';
+      if(isAtris) {
+          specialTooltip = `<div class="relative group"><svg xmlns="http://www.w3.org/2000/svg" class="h-5 w-5 text-accent" viewBox="0 0 20 20" fill="currentColor"><path fill-rule="evenodd" d="M18 10a8 8 0 11-16 0 8 8 0 0116 0zm-7-4a1 1 0 11-2 0 1 1 0 012 0zM9 9a1 1 0 000 2v3a1 1 0 001 1h1a1 1 0 100-2v-3a1 1 0 00-1-1H9z" clip-rule="evenodd" /></svg><div class="absolute bottom-full mb-2 w-64 bg-white text-body text-xs rounded-lg py-2 px-3 opacity-0 group-hover:opacity-100 transition-opacity duration-300 pointer-events-none z-10 border border-accent-soft">Upozornění: Pro fondy ATRIS se jako datum zainvestování pro výpočet použije 5. den následujícího měsíce po datu připsání.</div></div>`;
+      }
+      const section = document.createElement('section');
+      section.className = 'card p-7 sm:p-8 space-y-6';
+      section.innerHTML = `<div class="flex flex-col gap-4 md:flex-row md:items-start md:justify-between"><div class="space-y-1.5"><h2 class="text-xl font-semibold text-primary flex items-center gap-2"><span>Vstupy – ${providerName.replace('&', '&amp;')}</span>${specialTooltip}</h2><p class="text-sm text-muted">Spravujte transakce a sledujte výkonnost jednotlivých fondů.</p></div><div class="flex flex-wrap gap-2 text-sm"><button data-provider="${providerKey}" data-action="add-row" type="button" class="primary-btn px-4 py-2 rounded-xl text-sm font-medium flex items-center gap-2"><span>+ Přidat řádek</span></button><button data-provider="${providerKey}" data-action="add-sample" type="button" class="secondary-btn px-4 py-2 rounded-xl text-sm font-medium">Ukázka</button><button data-provider="${providerKey}" data-action="delete-all" type="button" class="danger-btn px-4 py-2 rounded-xl text-sm font-medium">Smazat vše</button></div></div><div class="overflow-x-auto rounded-2xl border border-accent-soft bg-card-soft"><table class="w-full text-sm border-separate border-spacing-x-2 text-body"><thead><tr class="text-xs uppercase tracking-[0.18em] text-muted"><th class="py-3 pr-3 font-semibold text-left w-[260px]">Fond</th><th class="py-3 pr-3 font-semibold text-right">Čistá investice</th><th class="py-3 pr-3 font-semibold text-left">Datum připsání</th><th class="py-3 pr-3 font-semibold text-right">Počet CP</th><th class="py-3 pr-3 font-semibold text-right border-l border-subtle">Upis. NAV</th><th class="py-3 pr-3 font-semibold text-right">Poslední NAV</th><th class="py-3 pr-3 font-semibold text-right">Aktuální hodnota</th><th class="py-3 pr-3 font-semibold text-left border-l border-subtle">Datum ocenění</th><th class="py-3 pr-3 font-semibold text-left">Měna</th><th class="py-3 font-semibold w-[60px]"></th></tr></thead><tbody data-tbody-for="${providerKey}"></tbody></table></div>`;
+      return section;
+  };
+  const createInputRow = (providerKey, rowData) => {
+      const tr = document.createElement('tr');
+      const isFrozen = !!rowData.freeze;
+      tr.className = 'fade-in' + (isFrozen ? ' is-frozen-row' : '');
+      tr.dataset.id = rowData.id;
+      const nameCell = document.createElement('td');
+      nameCell.className = 'py-1 pr-3';
+      const nameWrap = document.createElement('div');
+      nameWrap.className = 'relative flex items-center gap-2';
+      const nameDiv = document.createElement('div');
+      nameDiv.contentEditable = true;
+      nameDiv.className = 'editable flex-1 min-w-0';
+      nameDiv.textContent = rowData.fund || '';
+      nameDiv.dataset.ph = 'Název fondu...';
+      nameDiv.dataset.key = 'fund';
+      nameWrap.appendChild(nameDiv);
+      /* PATCH */
+      const freezeBtn = document.createElement('button');
+      freezeBtn.type = 'button';
+      freezeBtn.className = 'freeze-toggle';
+      freezeBtn.dataset.action = 'toggle-freeze';
+      freezeBtn.dataset.id = rowData.id;
+      freezeBtn.dataset.provider = providerKey;
+      freezeBtn.setAttribute('aria-pressed', String(isFrozen));
+      freezeBtn.textContent = isFrozen ? 'Odmrazit' : 'Zmrazit';
+      nameWrap.appendChild(freezeBtn);
+      nameCell.appendChild(nameWrap);
+      const createCell = (content) => { const td = document.createElement('td'); td.className = 'py-1 align-middle'; td.appendChild(content); return td; };
+      const createInput = (key, type, extraClass = '') => {
+          const input = document.createElement('input');
+          input.type = type;
+          input.className = `glass-input px-2.5 py-1.5 rounded-lg border w-full transition-all text-primary ${extraClass}`;
+          let displayValue = rowData[key] || '';
+          if (['invest', 'totalCurrent'].includes(key)) {
+              const num = utils.numCZ(displayValue);
+              if (isFinite(num)) {
+                  displayValue = fmt0.format(num);
+              }
+          }
+          input.value = displayValue;
+          if (type === 'text' && key.toLowerCase().includes('date')) { input.placeholder = 'dd.mm.rrrr'; }
+          input.dataset.key = key;
+          return input;
+      };
+      const createSelect = (key) => {
+          const select = document.createElement('select');
+          select.className = 'glass-input px-2.5 py-1.5 rounded-lg border w-full bg-white text-primary';
+          select.dataset.key = key;
+          ['CZK', 'EUR'].forEach(c => {
+              const option = document.createElement('option');
+              option.value = c;
+              option.textContent = c;
+              if (c === rowData[key]) option.selected = true;
+              select.appendChild(option);
+          });
+          return select;
+      };
+      const delBtnCell = document.createElement('td');
+      delBtnCell.className = 'py-1 text-right';
+      const delBtn = document.createElement('button');
+      delBtn.innerHTML = `<svg xmlns="http://www.w3.org/2000/svg" class="h-5 w-5" viewBox="0 0 20 20" fill="currentColor"><path fill-rule="evenodd" d="M9 2a1 1 0 00-.894.553L7.382 4H4a1 1 0 000 2v10a2 2 0 002 2h8a2 2 0 002-2V6a1 1 0 100-2h-3.382l-.724-1.447A1 1 0 0011 2H9zM7 8a1 1 0 012 0v6a1 1 0 11-2 0V8zm4 0a1 1 0 012 0v6a1 1 0 11-2 0V8z" clip-rule="evenodd" /></svg>`;
+      delBtn.className = 'p-1.5 rounded-lg transition-colors delete-row-button';
+      delBtn.title = "Smazat řádek";
+      delBtn.dataset.action = 'delete-row';
+      delBtn.dataset.id = rowData.id;
+      delBtn.dataset.provider = providerKey;
+      delBtnCell.appendChild(delBtn);
+      tr.append(
+          nameCell,
+          createCell(createInput('invest', 'text', 'tabular text-right')),
+          createCell(createInput('dateIn', 'text')),
+          createCell(createInput('qty', 'text', 'tabular text-right')),
+          createCell(createInput('issueNav', 'text', 'tabular text-right border-l border-subtle')),
+          createCell(createInput('currNav', 'text', 'tabular text-right')),
+          createCell(createInput('totalCurrent', 'text', 'tabular text-right')),
+          createCell(createInput('currDate', 'text', 'border-l border-subtle')),
+          createCell(createSelect('curr')),
+          delBtnCell
+      );
+      return tr;
+  };
+  const renderProviderInputs = (providerKey, newRowId = null) => {
+      const tbody = document.querySelector(`[data-tbody-for="${providerKey}"]`);
+      if (!tbody) return;
+      const fragment = document.createDocumentFragment();
+      state.rows[providerKey].forEach(row => { fragment.appendChild(createInputRow(providerKey, row)); });
+      tbody.innerHTML = '';
+      tbody.appendChild(fragment);
+      if (newRowId) {
+          const newRowEl = tbody.querySelector(`[data-id="${newRowId}"]`);
+          if (newRowEl) { newRowEl.querySelector('[data-key="fund"]').focus(); }
+      }
+  };
+  const renderAllInputs = () => { Object.keys(PROVIDERS).forEach(key => renderProviderInputs(key)); };
+
+  const parseRow = r => ({
+      id: r.id,
+      fund: utils.normName(r.fund),
+      invest: utils.numCZ(r.invest),
+      totalCurrent: utils.numCZ(r.totalCurrent),
+      dateIn: utils.toDate(r.dateIn),
+      qty: utils.numCZ(r.qty),
+      issueNav: utils.numCZ(r.issueNav),
+      currNav: utils.numCZ(r.currNav),
+      currDate: utils.toDate(r.currDate),
+      curr: r.curr || 'CZK',
+      /* PATCH */
+      freeze: !!r.freeze,
+  });
+  const getRowStatus = (p) => {
+      let missing = [];
+      let conflicts = [];
+      const hasTotalPath = isFinite(p.invest) && p.invest > 0 && isFinite(p.totalCurrent) && p.totalCurrent > 0 && p.dateIn && p.currDate;
+      const hasUnitPath = isFinite(p.issueNav) && p.issueNav > 0 && isFinite(p.currNav) && p.currNav > 0 && (isFinite(p.qty) || isFinite(p.invest)) && p.dateIn && p.currDate;
+      if (!p.fund) missing.push('název fondu');
+      if (!p.dateIn) missing.push('datum připsání');
+      if (!p.currDate) missing.push('datum ocenění');
+      if (!hasTotalPath && !hasUnitPath) missing.push('min. vstupů');
+      const calculatedInvest = p.qty * p.issueNav;
+      if(isFinite(p.invest) && isFinite(calculatedInvest) && Math.abs(p.invest - calculatedInvest) > 1e-2) conflicts.push(`Investice ≠ Počet CP × Upis. NAV`);
+      const calculatedCurrent = p.qty * p.currNav;
+      if(isFinite(p.totalCurrent) && isFinite(calculatedCurrent) && Math.abs(p.totalCurrent - calculatedCurrent) > 1e-2) conflicts.push(`Akt. hodnota ≠ Počet CP × Posl. NAV`);
+      if (conflicts.length > 0) return ['conflict', conflicts.join('; ')];
+      if (missing.length > 0) return ['error', `Chybějící pole: ${missing.join(', ')}`];
+      return ['ok', ''];
+  };
+  const processAllRows = () => {
+      const processedFunds = [];
+      const allCurrencies = new Set();
+      Object.entries(state.rows).forEach(([providerKey, providerRows]) => {
+          providerRows.forEach(rawRow => {
+              allCurrencies.add(rawRow.curr || 'CZK');
+              let p = parseRow(rawRow);
+              const [status, _] = getRowStatus(p);
+              if (status === 'error') return;
+              let effectiveDateIn = p.dateIn;
+              if (providerKey === 'atris' && p.dateIn) {
+                  effectiveDateIn = new Date(p.dateIn.getFullYear(), p.dateIn.getMonth() + 1, 5);
+              }
+              let invest = p.invest;
+              let qty = p.qty;
+              let current = p.totalCurrent;
+              if (!isFinite(qty) && isFinite(p.invest) && isFinite(p.issueNav) && p.issueNav > 0) qty = p.invest / p.issueNav;
+              if (!isFinite(invest) && isFinite(p.qty) && isFinite(p.issueNav) && p.issueNav > 0) invest = p.qty * p.issueNav;
+              if (!isFinite(current) && isFinite(qty) && isFinite(p.currNav) && p.currNav > 0) current = qty * p.currNav;
+              if (!isFinite(invest) || !isFinite(current) || !effectiveDateIn || !p.currDate) return;
+            /* PATCH */
+            const valuationDate = p.currDate;
+            /* PATCH */
+            const hasValidValuation = !!(effectiveDateIn && valuationDate && valuationDate >= effectiveDateIn);
+            const months = utils.monthsDiff(effectiveDateIn, valuationDate);
+            const ret = (isFinite(invest) && invest > 0 && isFinite(current)) ? (current / invest - 1) : NaN;
+            /* PATCH */
+            const irr = (hasValidValuation && isFinite(invest) && invest > 0 && isFinite(current))
+                ? finance.xirr([{ date: effectiveDateIn, amount: -invest }, { date: valuationDate, amount: current }])
+                : NaN;
+            processedFunds.push({
+                ...p,
+                invest, qty, current,
+                pnl: isFinite(invest) && isFinite(current) ? current - invest : NaN,
+                ret, months, irr,
+                dateIn: effectiveDateIn,
+                originalDateIn: p.dateIn,
+                /* PATCH */ hasValidValuation,
+                /* PATCH */ freeze: !!p.freeze
+            });
+        });
+    });
+      const { funds, hasMixedCurrencies: hasMixed } = { funds: processedFunds, hasMixedCurrencies: allCurrencies.size > 1 };
+      const outCurr = elements.outCurrency?.value || 'CZK';
+      const fxRate = utils.numCZ(elements.fxRate?.value);
+      const portfolioSummary = calculateSummary(funds, outCurr, fxRate);
+      const activeFunds = funds.filter(f => !f.freeze);
+      state.lastProcessedData = { funds, activeFunds, hasMixedCurrencies: hasMixed, portfolioSummary };
+      return state.lastProcessedData;
+  };
+
+  const recalculateAndRender = () => {
+    const { funds, activeFunds, hasMixedCurrencies, portfolioSummary } = processAllRows();
+    const outCurr = elements.outCurrency?.value || 'CZK';
+    const fxRate = utils.numCZ(elements.fxRate?.value);
+    const hasValidFx = Number.isFinite(fxRate) && fxRate > 0;
+    const statusContainer = elements.statusContainer || document.getElementById('status-container');
+    if (statusContainer) {
+        if (hasMixedCurrencies && !hasValidFx) {
+            statusContainer.innerHTML = `<div class="rounded-2xl border border-accent-soft bg-accent-soft p-5 text-sm text-body"><strong class="text-primary">Chybějící kurz:</strong> Pro správné zobrazení výsledků v cílové měně ${outCurr} je potřeba vyplnit směnný kurz EUR/CZK.</div>`;
+        } else {
+            statusContainer.innerHTML = '';
+        }
+    }
+    renderResults(funds, activeFunds, outCurr, fxRate, hasMixedCurrencies, portfolioSummary);
+    calculateAnnuity();
+  };
+  const renderResults = (funds, activeFunds, outCurr, fxRate, hasMixedCurrencies, portfolioSummary) => {
+    const groupedFunds = funds.reduce((acc, f) => { if(!f.fund) return acc; const key = f.fund; if (!acc[key]) acc[key] = []; acc[key].push(f); return acc; }, {});
+    Object.values(groupedFunds).forEach(group => group.sort((a, b) => a.dateIn - b.dateIn));
+    Object.keys(groupedFunds).forEach(name => getColor(name));
+    renderFundsByCard(groupedFunds, outCurr, fxRate);
+    const hasValidFx = Number.isFinite(fxRate) && fxRate > 0;
+    renderSummary(portfolioSummary, outCurr, { hasMixedCurrencies, hasFx: hasValidFx });
+    renderCharts(groupedFunds, funds, activeFunds, outCurr, fxRate, hasMixedCurrencies, portfolioSummary);
+  };
+
+  const calculateSummary = (funds, outCurr, fxRate) => {
+    const convert = (amt, from) => utils.convertAmount(amt, from, outCurr, fxRate);
+    const activeFunds = funds.filter(f => !f.freeze);
+    let totalInvestAll = 0;
+    let totalCurrentAll = 0;
+    let totalInvestActive = 0;
+    let totalCurrentActive = 0;
+    let weightedDurationSum = 0;
+    let minValuationDate = null;
+    let maxValuationDate = null;
+    /* PATCH */
+    let latestIrrDate = null;
+    /* PATCH */
+    let irrCurrentTotal = 0;
+    const cfsForIrr = [];
+    funds.forEach(r => {
+        const convertedInvest = convert(r.invest, r.curr);
+        const convertedCurrent = convert(r.current, r.curr);
+        if (isFinite(convertedInvest)) {
+            totalInvestAll += convertedInvest;
+        }
+        if (isFinite(convertedCurrent)) {
+            totalCurrentAll += convertedCurrent;
+        }
+        if (r.currDate) {
+            if (!minValuationDate || r.currDate < minValuationDate) minValuationDate = r.currDate;
+            if (!maxValuationDate || r.currDate > maxValuationDate) maxValuationDate = r.currDate;
+        }
+    });
+    activeFunds.forEach(r => {
+        const convertedInvest = convert(r.invest, r.curr);
+        const convertedCurrent = convert(r.current, r.curr);
+        if (isFinite(convertedInvest)) {
+            totalInvestActive += convertedInvest;
+            if (r.hasValidValuation) {
+                cfsForIrr.push({ date: r.dateIn, amount: -convertedInvest });
+                if (isFinite(r.months)) {
+                    weightedDurationSum += convertedInvest * r.months;
+                }
+            }
+        }
+        if (isFinite(convertedCurrent)) {
+            totalCurrentActive += convertedCurrent;
+            if (r.hasValidValuation) {
+                irrCurrentTotal += convertedCurrent;
+                if (r.currDate && (!latestIrrDate || r.currDate > latestIrrDate)) {
+                    latestIrrDate = r.currDate;
+                }
+            }
+        }
+    });
+    if (cfsForIrr.length > 0 && isFinite(irrCurrentTotal) && latestIrrDate) {
+        cfsForIrr.push({ date: latestIrrDate, amount: irrCurrentTotal });
+    }
+    const totalPnlAll = totalCurrentAll - totalInvestAll;
+    const totalPnlActive = totalCurrentActive - totalInvestActive;
+    /* PATCH */
+    const totalRetAll = totalInvestAll > 0 ? (totalPnlAll / totalInvestAll) : NaN;
+    /* PATCH */
+    const totalRetActive = totalInvestActive > 0 ? (totalPnlActive / totalInvestActive) : NaN;
+    const portfolioIrr = cfsForIrr.length > 1 ? finance.xirr(cfsForIrr) : NaN;
+    const weightedAvgMonths = totalInvestActive > 0 ? weightedDurationSum / totalInvestActive : NaN;
+    return {
+        totalInvestConverted: totalInvestAll,
+        totalCurrentConverted: totalCurrentAll,
+        totalPnl: totalPnlAll,
+        /* PATCH */
+        totalRet: totalRetAll,
+        portfolioIrr,
+        weightedAvgMonths,
+        minValuationDate,
+        maxValuationDate,
+        hasData: totalInvestAll > 0 || totalCurrentAll > 0,
+        /* PATCH */
+        totalInvestActive,
+        /* PATCH */
+        totalCurrentActive,
+        /* PATCH */
+        totalPnlActive,
+        /* PATCH */
+        totalRetActive,
+        /* PATCH */
+        hasActive: totalInvestActive > 0 || totalCurrentActive > 0,
+        /* PATCH */
+        hasFrozen: activeFunds.length !== funds.length
+    };
+  };
+
+  const renderFundsByCard = (groupedFunds, outCurr, fxRate, options = {}) => {
+      const { isStaticExport = false, container: providedContainer } = options;
+      const container = providedContainer || elements.fundsContainer || document.getElementById('funds-by-card-container');
+      if (!isStaticExport && !container) return '';
+
+      /* PATCH */
+      const staticCopy = isStaticExport ? (options.copy || null) : null;
+      /* PATCH */
+      const formatOptions = isStaticExport ? (options.format || {}) : {};
+      /* PATCH */
+      const currencyFormat = formatOptions.currency || {};
+      /* PATCH */
+      const percentFormat = formatOptions.percent || {};
+      /* PATCH */
+      const monthsFormat = formatOptions.months || {};
+      /* PATCH */
+      const languageOverride = isStaticExport ? (options.language || 'cs') : 'cs';
+
+      const convert = (amt, from) => utils.convertAmount(amt, from, outCurr, fxRate);
+      const fundEntries = Object.entries(groupedFunds);
+
+      if (!isStaticExport && elements.amountNoteFunds) {
+          elements.amountNoteFunds.textContent = `Částky v ${outCurr}`;
+      }
+
+      if (fundEntries.length === 0) {
+          const emptyMessage = isStaticExport && staticCopy?.noData ? staticCopy.noData : 'Nejsou k dispozici žádná data pro výpočet.';
+          const emptyState = `<div class="card p-6 text-center muted-text">${htmlEscape(emptyMessage)}</div>`;
+          if (isStaticExport) {
+              return emptyState;
+          }
+          container.innerHTML = emptyState;
+          return;
+      }
+
+      const buildMetrics = (metrics, variant = 'interactive') => metrics.map(({ label, value, extraClass = '', note = '' }) => {
+          if (variant === 'interactive') {
+              return `<div class="fund-card__metric"><span class="metric-label">${label}</span><span class="metric-value ${extraClass}">${value}</span>${note ? `<span class="metric-sub">${note}</span>` : ''}</div>`;
+          }
+          return `<div class="fund-export__metric"><span class="metric-label">${label}</span><span class="metric-value ${extraClass}">${value}</span>${note ? `<span class="metric-sub">${note}</span>` : ''}</div>`;
+      }).join('');
+
+      const cards = fundEntries.map(([name, investments]) => {
+          investments.sort((a, b) => a.dateIn - b.dateIn);
+          let totalInvest = 0;
+          let totalCurrent = 0;
+          let weightedDurationSum = 0;
+          /* PATCH */
+          const cfs = [];
+          /* PATCH */
+          let irrCurrentTotal = 0;
+
+          investments.forEach(inv => {
+              const invConverted = convert(inv.invest, inv.curr);
+              const currConverted = convert(inv.current, inv.curr);
+              if (isFinite(invConverted)) {
+                  totalInvest += invConverted;
+                  /* PATCH */
+                  if (inv.hasValidValuation) {
+                      cfs.push({ date: inv.dateIn, amount: -invConverted });
+                  }
+                  if (isFinite(inv.months)) {
+                      weightedDurationSum += invConverted * inv.months;
+                  }
+              }
+              if (isFinite(currConverted)) {
+                  totalCurrent += currConverted;
+                  /* PATCH */
+                  if (inv.hasValidValuation) {
+                      irrCurrentTotal += currConverted;
+                  }
+              }
+          });
+
+          const latestDate = investments.reduce((max, entry) => (entry.currDate && entry.currDate > max ? entry.currDate : max), new Date(0));
+          /* PATCH */
+          const latestValidDate = investments.reduce((max, entry) => {
+              if (entry.hasValidValuation && entry.currDate && (!max || entry.currDate > max)) {
+                  return entry.currDate;
+              }
+              return max;
+          }, null);
+          /* PATCH */
+          if (cfs.length > 0 && latestValidDate) {
+              cfs.push({ date: latestValidDate, amount: irrCurrentTotal });
+          }
+
+          /* PATCH */
+          const fundIrr = cfs.length > 1 ? finance.xirr(cfs) : NaN;
+          const pnl = totalCurrent - totalInvest;
+          /* PATCH */
+          const isFrozenFund = investments.every(inv => inv.freeze);
+          /* PATCH */
+          const frozenLabel = languageOverride === 'en' ? 'Frozen' : 'Zmrazeno';
+          /* PATCH */
+          const freezeBadgeInteractive = isFrozenFund ? `<span class="freeze-badge">${frozenLabel}</span>` : '';
+          /* PATCH */
+          const freezeBadgeExport = freezeBadgeInteractive;
+          const weightedAvgMonths = totalInvest > 0 ? weightedDurationSum / totalInvest : NaN;
+          const fundColor = getColor(name);
+          const pnlClass = pnl >= 0 ? 'text-positive' : 'text-negative';
+          const irrClass = isFinite(fundIrr) && fundIrr >= 0 ? 'text-positive' : 'text-negative';
+          const safeName = htmlEscape(name);
+
+          const metrics = isStaticExport && staticCopy
+              ? [
+                  { label: staticCopy.metrics.invested, value: formatCurrency0(totalInvest, outCurr, currencyFormat) },
+                  { label: staticCopy.metrics.current, value: formatCurrency0(totalCurrent, outCurr, currencyFormat) },
+                  { label: staticCopy.metrics.pnl, value: formatCurrency0(pnl, outCurr, currencyFormat), extraClass: pnlClass },
+                  { label: staticCopy.metrics.irr, value: formatXirr1(fundIrr, { ...percentFormat, language: languageOverride }), extraClass: irrClass },
+                  { label: staticCopy.metrics.months, value: formatMonths0(weightedAvgMonths, { ...monthsFormat, language: languageOverride }) }
+              ]
+              : [
+                  { label: 'Investováno', value: formatCurrency0(totalInvest, outCurr) },
+                  { label: 'Aktuální hodnota', value: formatCurrency0(totalCurrent, outCurr) },
+                  { label: 'Čistý výnos', value: formatCurrency0(pnl, outCurr), extraClass: pnlClass },
+                  { label: 'Průměrný roční výnos (XIRR)', value: formatXirr1(fundIrr) , extraClass: irrClass },
+                  { label: 'Průměrná doba investice', value: formatMonths0(weightedAvgMonths) }
+              ];
+
+          const transactionRows = investments.map((inv, index) => {
+              const convertedCurrent = convert(inv.current, inv.curr);
+              const convertedInvest = convert(inv.invest, inv.curr);
+              const convertedPnl = isFinite(convertedCurrent) && isFinite(convertedInvest) ? convertedCurrent - convertedInvest : NaN;
+              const displayDate = inv.originalDateIn || inv.dateIn;
+              if (isStaticExport && staticCopy) {
+                  const rowLabel = index === 0 ? staticCopy.transactionFirst : staticCopy.transactionNext(index);
+                  const dateLabel = displayDate ? formatDateByLanguage(displayDate, languageOverride) : 'N/A';
+                  return `<tr>
+                <td>${htmlEscape(rowLabel)} <span class="muted">(${htmlEscape(dateLabel)})</span></td>
+                <td class="text-right">${formatCurrency0(convertedInvest, outCurr, currencyFormat)}</td>
+                <td class="text-right ${convertedPnl >= 0 ? 'text-positive' : 'text-negative'}">${formatCurrency0(convertedPnl, outCurr, currencyFormat)}</td>
+                <td class="text-right">${formatCurrency0(convertedCurrent, outCurr, currencyFormat)}</td>
+                <td class="text-right">${formatMonths0(inv.months, { ...monthsFormat, language: languageOverride })}</td>
+                <td class="text-right">${formatXirr1(inv.irr, { ...percentFormat, language: languageOverride })}</td>
+              </tr>`;
+              }
+              return `<tr>
+                <td>${index === 0 ? 'První vklad' : `Dokup #${index}`} <span class="muted">(${displayDate ? displayDate.toLocaleDateString('cs-CZ') : 'N/A'})</span></td>
+                <td class="text-right">${formatCurrency0(convertedInvest, outCurr)}</td>
+                <td class="text-right ${convertedPnl >= 0 ? 'text-positive' : 'text-negative'}">${formatCurrency0(convertedPnl, outCurr)}</td>
+                <td class="text-right">${formatCurrency0(convertedCurrent, outCurr)}</td>
+                <td class="text-right">${formatMonths0(inv.months)}</td>
+                <td class="text-right">${formatXirr1(inv.irr)}</td>
+              </tr>`;
+          }).join('');
+
+          if (isStaticExport) {
+              const metricsHtml = buildMetrics(metrics, 'static');
+              const initials = getFundInitials(name);
+              /* PATCH */
+              const metaChipSource = staticCopy?.metaChips
+                  ? [
+                      staticCopy.metaChips.transactions(investments.length),
+                      latestDate ? staticCopy.metaChips.valuation(formatDateByLanguage(latestDate, languageOverride)) : null,
+                      staticCopy.metaChips.currency(outCurr)
+                  ]
+                  : [
+                      `Transakcí ${investments.length}`,
+                      latestDate ? `Ocenění ${latestDate.toLocaleDateString('cs-CZ')}` : null,
+                      `Cílová měna ${outCurr}`
+                  ];
+              if (isFrozenFund) {
+                  metaChipSource.push(staticCopy?.metaChips?.frozen || (languageOverride === 'en' ? 'Frozen fund' : 'Fond je zmrazen'));
+              }
+              const metaChips = metaChipSource.filter(Boolean).map(chip => `<span>${htmlEscape(chip)}</span>`).join('');
+
+              return `<article class="fund-export">
+  <div class="fund-export__header">
+    <div class="fund-avatar" style="background:${fundColor}">${initials}</div>
+    <div class="fund-export__title">
+      <div class="fund-card__name">${safeName} ${freezeBadgeExport}</div>
+      <div class="fund-export__meta">${metaChips}</div>
+    </div>
+  </div>
+  <div class="fund-export__metrics">${metricsHtml}</div>
+  <div class="fund-export__table-wrapper">
+    <table class="fund-export__table">
+      <thead>
+        <tr>
+          <th>${staticCopy ? htmlEscape(staticCopy.tableHeaders.transaction) : 'Transakce'}</th>
+          <th class="text-right">${staticCopy ? htmlEscape(staticCopy.tableHeaders.invested) : 'Investice'}</th>
+          <th class="text-right">${staticCopy ? htmlEscape(staticCopy.tableHeaders.pnl) : 'Výnos'}</th>
+          <th class="text-right">${staticCopy ? htmlEscape(staticCopy.tableHeaders.current) : 'Aktuální hodnota'}</th>
+          <th class="text-right">${staticCopy ? htmlEscape(staticCopy.tableHeaders.months) : 'Doba držení'}</th>
+          <th class="text-right">${staticCopy ? htmlEscape(staticCopy.tableHeaders.irr) : 'Prům. roční výnos'}</th>
+        </tr>
+      </thead>
+      <tbody>${transactionRows}</tbody>
+    </table>
+  </div>
+</article>`;
+          }
+
+          const metricsHtml = buildMetrics(metrics);
+          const initials = getFundInitials(name);
+          /* PATCH */
+          const metaChipList = [
+              `Transakcí ${investments.length}`,
+              latestDate ? `Ocenění ${latestDate.toLocaleDateString('cs-CZ')}` : null,
+              `Cílová měna ${outCurr}`
+          ];
+          if (isFrozenFund) {
+              metaChipList.push(languageOverride === 'en' ? 'Frozen fund' : 'Fond je zmrazen');
+          }
+          const metaChips = metaChipList.filter(Boolean).map(chip => `<span>${chip}</span>`).join('');
+
+          return `<div class="card p-6 sm:p-7">
+  <div class="flex flex-col gap-5">
+    <div class="fund-card__header">
+      <div class="fund-avatar" style="background:${fundColor}">${initials}</div>
+      <div class="flex flex-col gap-3">
+        <div class="flex items-center gap-3 flex-wrap">
+          <span class="fund-card__dot" style="background-color: ${fundColor}"></span>
+          <span class="fund-card__name" title="${safeName}">${safeName}</span>
+          ${freezeBadgeInteractive}
+        </div>
+        <div class="fund-card__meta">${metaChips}</div>
+      </div>
+    </div>
+    <div class="fund-card__metrics">${metricsHtml}</div>
+    <details class="fund-card__transactions">
+      <summary>Zobrazit transakce <svg class="summary-arrow w-4 h-4" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20" fill="currentColor"><path fill-rule="evenodd" d="M7.21 14.77a.75.75 0 01.02-1.06L11.168 10 7.23 6.29a.75.75 0 111.04-1.08l4.5 4.25a.75.75 0 010 1.08l-4.5 4.25a.75.75 0 01-1.06-.02z" clip-rule="evenodd" /></svg></summary>
+      <div class="fund-export__table-wrapper">
+        <table class="fund-export__table">
+          <thead>
+            <tr>
+              <th>Transakce</th>
+              <th class="text-right">Investice</th>
+              <th class="text-right">Výnos</th>
+              <th class="text-right">Aktuální hodnota</th>
+              <th class="text-right">Doba držení</th>
+              <th class="text-right">Prům. roční výnos</th>
+            </tr>
+          </thead>
+          <tbody>${transactionRows}</tbody>
+        </table>
+      </div>
+    </details>
+  </div>
+</div>`;
+      });
+
+      if (isStaticExport) {
+          return cards.join('');
+      }
+
+      container.innerHTML = cards.join('');
+  };
+  const renderSummary = (summaryData, outCurr, options = {}) => {
+    const { isStaticExport = false, hasMixedCurrencies = false, hasFx = true } = options;
+    const tone = options.tone === 'tykani' ? 'tykani' : 'vykani';
+    const summaryContainer = options.container || elements.portfolioSummary || document.getElementById('portfolio-summary-content');
+    /* PATCH */
+    const formatOptions = options.format || {};
+    /* PATCH */
+    const currencyFormat = formatOptions.currency || {};
+    /* PATCH */
+    const percentFormat = formatOptions.percent || {};
+    /* PATCH */
+    const monthsFormat = formatOptions.months || {};
+    /* PATCH */
+    const summaryLabelsOverride = options.summaryLabels;
+    /* PATCH */
+    const languageOverride = options.language || 'cs';
+
+    if (!isStaticExport && elements.amountNotePortfolio) {
+        elements.amountNotePortfolio.textContent = `Částky v ${outCurr}`;
+    }
+
+    if (!summaryData.hasData) {
+        const empty = `<div class="rounded-2xl border border-subtle bg-card-muted py-10 text-center text-muted">Žádná data pro souhrn.</div>`;
+        if (isStaticExport) {
+            return empty;
+        }
+        if (summaryContainer) {
+            summaryContainer.innerHTML = empty;
+        }
+        return;
+    }
+
+    const { totalInvestConverted, totalCurrentConverted, totalPnl, totalRet, portfolioIrr, weightedAvgMonths, minValuationDate, maxValuationDate } = summaryData;
+    /* PATCH */
+    const displayRetAll = (isFinite(totalInvestConverted) && totalInvestConverted > 0)
+        ? ((totalCurrentConverted - totalInvestConverted) / totalInvestConverted)
+        : totalRet;
+    const pnlClassInteractive = totalPnl >= 0 ? 'text-positive' : 'text-negative';
+    const pnlClassExport = totalPnl >= 0 ? 'text-positive' : 'text-negative';
+    const irrClassInteractive = isFinite(portfolioIrr) ? (portfolioIrr >= 0 ? 'text-positive' : 'text-negative') : '';
+    const irrClassExport = isFinite(portfolioIrr) ? (portfolioIrr >= 0 ? 'text-positive' : 'text-negative') : '';
+    let dateDisclaimer = '';
+    /* PATCH */
+    const dateLocale = languageOverride === 'en' ? 'en-GB' : 'cs-CZ';
+    if (minValuationDate && maxValuationDate) {
+        const minStr = minValuationDate.toLocaleDateString(dateLocale);
+        const maxStr = maxValuationDate.toLocaleDateString(dateLocale);
+        if (languageOverride === 'en') {
+            dateDisclaimer = minStr === maxStr
+                ? `Values are current as of ${maxStr}.`
+                : `Values are current as of the latest available dates between ${minStr} and ${maxStr}.`;
+        } else {
+            dateDisclaimer = minStr === maxStr
+                ? `Hodnoty jsou platné k ${maxStr}.`
+                : `Hodnoty jsou platné k posledním známým datům v rozmezí ${minStr} – ${maxStr}.`;
+        }
+    }
+
+    if (isStaticExport) {
+        /* PATCH */
+        const formatted = {
+            totalInvest: formatCurrency0(totalInvestConverted, outCurr, currencyFormat),
+            totalCurrent: formatCurrency0(totalCurrentConverted, outCurr, currencyFormat),
+            totalPnl: formatCurrency0(totalPnl, outCurr, currencyFormat),
+            totalRet: formatPercent1(displayRetAll, percentFormat),
+            irr: formatXirr1(portfolioIrr, { ...percentFormat, language: languageOverride }),
+            weightedMonths: formatMonths0(weightedAvgMonths, { ...monthsFormat, language: languageOverride })
+        };
+        /* PATCH */
+        if (options.formattedTotals) {
+            if (options.formattedTotals.totalInvest) formatted.totalInvest = options.formattedTotals.totalInvest;
+            if (options.formattedTotals.totalCurrent) formatted.totalCurrent = options.formattedTotals.totalCurrent;
+            if (options.formattedTotals.totalPnl) formatted.totalPnl = options.formattedTotals.totalPnl;
+            if (options.formattedTotals.totalRet) formatted.totalRet = options.formattedTotals.totalRet;
+            if (options.formattedTotals.irr) formatted.irr = options.formattedTotals.irr;
+            if (options.formattedTotals.weightedMonths) formatted.weightedMonths = options.formattedTotals.weightedMonths;
+        }
+        /* PATCH */
+        if (options.captureFormatted && typeof options.captureFormatted === 'object') {
+            Object.assign(options.captureFormatted, formatted);
+        }
+        const labelSet = summaryLabelsOverride || (tone === 'tykani'
+            ? {
+                totalInvest: 'TVÉ CELKOVÉ VKLADY',
+                totalCurrent: 'AKTUÁLNÍ HODNOTA',
+                totalPnl: 'TVŮJ ČISTÝ VÝNOS',
+                totalRet: 'CELKOVÉ ZHODNOCENÍ',
+                irr: 'PRŮMĚRNÝ ROČNÍ VÝNOS (XIRR)',
+                weightedMonths: 'PRŮMĚRNÁ DOBA INVESTICE'
+            }
+            : {
+                totalInvest: 'VAŠE CELKOVÉ VKLADY',
+                totalCurrent: 'AKTUÁLNÍ HODNOTA',
+                totalPnl: 'ČISTÝ VÝNOS',
+                totalRet: 'CELKOVÉ ZHODNOCENÍ',
+                irr: 'PRŮMĚRNÝ ROČNÍ VÝNOS (XIRR)',
+                weightedMonths: 'PRŮMĚRNÁ DOBA INVESTICE'
+            });
+        /* PATCH */
+        const totalRetToneExport = formatted.totalRet === '—' ? '' : pnlClassExport;
+        /* PATCH */
+        const irrToneClassExport = formatted.irr === '—' ? '' : irrClassExport;
+        const summaryMetrics = [
+            { label: labelSet.totalInvest, value: formatted.totalInvest },
+            { label: labelSet.totalCurrent, value: formatted.totalCurrent },
+            { label: labelSet.totalPnl, value: formatted.totalPnl, toneClass: pnlClassExport },
+            { label: labelSet.totalRet, value: formatted.totalRet, toneClass: totalRetToneExport },
+            { label: labelSet.irr, value: formatted.irr, toneClass: irrToneClassExport },
+            { label: labelSet.weightedMonths, value: formatted.weightedMonths }
+        ];
+
+        const cards = summaryMetrics.map(({ label, value, toneClass }) => `
+            <div class="summary-card">
+              <span class="summary-label">${label}</span>
+              <span class="summary-value ${toneClass ? toneClass : ''}">${value}</span>
+            </div>
+        `).join('');
+
+        /* PATCH */
+        const freezeNoteExport = summaryData.hasFrozen
+            ? (languageOverride === 'en'
+                ? 'Frozen funds are excluded from projected performance.'
+                : 'Zmrazené fondy nejsou zahrnuty do projekce výnosnosti.')
+            : '';
+        const exportContent = `<div class="summary-export">`
+          + `<div class="summary-grid">${cards}</div>`
+          + (dateDisclaimer ? `<p class="summary-note">${htmlEscape(dateDisclaimer)}</p>` : '')
+          + (freezeNoteExport ? `<p class="summary-note">${htmlEscape(freezeNoteExport)}</p>` : '')
+          + `</div>`;
+        return exportContent;
+    }
+
+    const formattedInteractive = {
+        totalInvest: formatCurrency0(totalInvestConverted, outCurr),
+        totalCurrent: formatCurrency0(totalCurrentConverted, outCurr),
+        totalPnl: formatCurrency0(totalPnl, outCurr),
+        totalRet: formatPercent1(displayRetAll),
+        irr: formatXirr1(portfolioIrr),
+        weightedMonths: formatMonths0(weightedAvgMonths)
+    };
+    /* PATCH */
+    const totalRetToneClass = formattedInteractive.totalRet === '—' ? '' : pnlClassInteractive;
+    /* PATCH */
+    const irrToneClassInteractive = formattedInteractive.irr === '—' ? '' : irrClassInteractive;
+    const showMixWarning = !isStaticExport && hasMixedCurrencies && !hasFx;
+    const mixWarningHtml = showMixWarning
+        ? `<div class="summary-warning">Portfolio obsahuje více měn bez zadaného kurzu. Částky nelze spolehlivě převést do ${htmlEscape(outCurr)}.</div>`
+        : '';
+    const interactiveMetrics = [
+      { label: 'VAŠE CELKOVÉ VKLADY', value: formattedInteractive.totalInvest },
+      { label: 'AKTUÁLNÍ HODNOTA', value: formattedInteractive.totalCurrent },
+      { label: 'ČISTÝ VÝNOS', value: formattedInteractive.totalPnl, toneClass: pnlClassInteractive },
+      { label: 'CELKOVÉ ZHODNOCENÍ', value: formattedInteractive.totalRet, toneClass: totalRetToneClass },
+      { label: 'PRŮMĚRNÝ ROČNÍ VÝNOS (XIRR)', value: formattedInteractive.irr, toneClass: irrToneClassInteractive },
+      { label: 'PRŮMĚRNÁ DOBA INVESTICE', value: formattedInteractive.weightedMonths }
+    ];
+    const interactiveCards = interactiveMetrics.map(({ label, value, toneClass }) => `
+      <div class="summary-card">
+        <span class="summary-label">${label}</span>
+        <span class="summary-value ${toneClass ? toneClass : ''}">${value}</span>
+      </div>
+    `).join('');
+    /* PATCH */
+    const freezeNoteInteractive = summaryData.hasFrozen
+        ? (languageOverride === 'en'
+            ? 'Frozen funds are excluded from projected performance.'
+            : 'Zmrazené fondy nejsou zahrnuty do projekce výnosnosti.')
+        : '';
+    const content = `<div class="summary-export">`
+      + `${mixWarningHtml}`
+      + `<div class="summary-grid">${interactiveCards}</div>`
+      + (dateDisclaimer ? `<p class="summary-note">${htmlEscape(dateDisclaimer)}</p>` : '')
+      + (freezeNoteInteractive ? `<p class="summary-note">${htmlEscape(freezeNoteInteractive)}</p>` : '')
+      + `</div>`;
+
+    if (summaryContainer) {
+        summaryContainer.innerHTML = content;
+    }
+  };
+
+  const renderCharts = (groupedFunds, funds, activeFunds, outCurr, fxRate, hasMixedCurrencies, portfolioSummary) => {
+    const chartsSection = elements.chartsSection || document.getElementById('charts-section');
+    const lineCard = elements.lineChartCard || document.getElementById('line-chart-card');
+    const pieCard = elements.pieChartCard || document.getElementById('pie-chart-card');
+    /* PATCH */
+    const activeDataset = Array.isArray(activeFunds) ? activeFunds : [];
+    /* PATCH */
+    const allDataset = Array.isArray(funds) ? funds : [];
+    if (allDataset.length > 0) {
+        lineCard.style.display = 'block';
+        const lineContainer = elements.lineChartContainer || document.getElementById('line-chart-container');
+        if (lineContainer) {
+            renderLineChart(lineContainer, allDataset, portfolioSummary.portfolioIrr, outCurr, fxRate, {
+                /* PATCH */ activeFunds: activeDataset,
+                /* PATCH */ frozenTotal: (portfolioSummary.totalCurrentConverted || 0) - (portfolioSummary.totalCurrentActive || 0)
+            });
+        }
+    } else {
+        lineCard.style.display = 'none';
+    }
+    const hasValidFx = Number.isFinite(fxRate) && fxRate > 0;
+    if (!hasMixedCurrencies || hasValidFx) {
+        const chartData = activeDataset;
+        if (chartData.length > 0) {
+            pieCard.style.display = 'block';
+            setupTimeSlider(activeDataset);
+        } else {
+            pieCard.style.display = 'none';
+        }
+    } else {
+        pieCard.style.display = 'block';
+        const pieContainer = elements.pieChartContainer || document.getElementById('pie-chart-container');
+        if (pieContainer) {
+        pieContainer.innerHTML = `<div class="text-center py-10 text-muted">Pro zobrazení grafu doplňte směnný kurz.</div>`;
+    }
+    }
+    if (chartsSection) {
+        chartsSection.style.display = (pieCard.style.display === 'block' || lineCard.style.display === 'block') ? 'block' : 'none';
+    }
+  };
+
+  const renderLineChart = (container, funds, portfolioIrr, outCurr, fxRate, options = {}) => {
+    /* PATCH */
+    const {
+        isStaticExport = false,
+        conversionReady = true,
+        formattedTodayValue: formattedTodayValueOverride = null,
+        copy: lineCopy = null,
+        format = {},
+        language = 'cs',
+        /* PATCH */ activeFunds: activeFundsOption = null,
+        /* PATCH */ frozenTotal: frozenTotalOption = null
+    } = options;
+
+    if (isStaticExport) {
+        const exportChart = buildLineChartForExport(
+            funds,
+            outCurr,
+            fxRate,
+            portfolioIrr,
+            conversionReady,
+            formattedTodayValueOverride,
+            /* PATCH */ { copy: lineCopy, format, language }
+        );
+        if (!exportChart.available) {
+            /* PATCH */
+            if (exportChart.reason === 'conversion') {
+                const conversionText = lineCopy?.conversion || 'Liniový graf nelze vytvořit bez platného převodu měn.';
+                return `<div class="rounded-2xl border border-subtle bg-card-muted py-10 text-center text-muted">${htmlEscape(conversionText)}</div>`;
+            }
+            const emptyText = lineCopy?.empty || 'Pro liniový graf nejsou k dispozici údaje.';
+            return `<div class="rounded-2xl border border-subtle bg-card-muted py-10 text-center text-muted">${htmlEscape(emptyText)}</div>`;
+        }
+        /* PATCH */
+        const legendLabels = lineCopy?.legend || {};
+        const baseLegend = htmlEscape(legendLabels.contributions || 'Kumulované vklady');
+        const valueLegend = htmlEscape(legendLabels.value || 'Hodnota');
+        const projectionLegend = htmlEscape(legendLabels.projection || 'Projekce');
+        const legend = exportChart.hasIrr
+            ? `<div class="line-legend"><span class="legend-pill legend-pill--base" tabindex="0">${baseLegend}</span><span class="legend-pill legend-pill--value" tabindex="0">${valueLegend}</span>${exportChart.irrPositive ? `<span class="legend-pill legend-pill--projection" tabindex="0">${projectionLegend}</span>` : ''}</div>`
+            : `<div class="line-legend"><span class="legend-pill legend-pill--base" tabindex="0">${baseLegend}</span></div>`;
+        const footnote = exportChart.footnote ? `<p class="chart-footnote">${htmlEscape(exportChart.footnote)}</p>` : '';
+        const ariaAttr = htmlEscape(exportChart.ariaLabel || 'Vývoj portfolia');
+        /* PATCH */
+        const pointsPayload = exportChart.hoverPoints ? htmlEscape(JSON.stringify(exportChart.hoverPoints)) : '';
+        /* PATCH */
+        const viewBoxPayload = exportChart.viewBox ? `${exportChart.viewBox.width},${exportChart.viewBox.height}` : '';
+        /* PATCH */
+        const canvasAttrs = pointsPayload
+            ? `class="line-canvas" role="img" aria-label="${ariaAttr}" data-line-points="${pointsPayload}" data-viewbox="${viewBoxPayload}"`
+            : `class="line-canvas" role="img" aria-label="${ariaAttr}"`;
+        return `<div class="line-export">${legend}<div ${canvasAttrs}>${exportChart.svg}</div>${footnote}</div>`;
+    }
+
+    if (!container) return;
+    container.innerHTML = "";
+    const convert = (amt, from) => utils.convertAmount(amt, from, outCurr, fxRate);
+    /* PATCH */
+    const allEvents = funds
+        .map(f => ({ date: f.dateIn, amount: convert(f.invest, f.curr), fund: f.fund, freeze: !!f.freeze }))
+        .filter(evt => evt.date instanceof Date && !isNaN(evt.date) && Number.isFinite(evt.amount) && evt.amount !== 0)
+        .sort((a, b) => a.date - b.date);
+    if (allEvents.length === 0) {
+        container.innerHTML = `<div class="rounded-2xl border border-subtle bg-card-muted py-10 text-center text-muted">Pro liniový graf nejsou k dispozici údaje.</div>`;
+        return;
+    }
+    /* PATCH */
+    const activeSet = Array.isArray(activeFundsOption) && activeFundsOption.length ? activeFundsOption : funds.filter(f => !f.freeze);
+    const today = new Date(); today.setHours(0,0,0,0);
+    const firstDate = allEvents[0].date;
+    const futureEndDate = new Date(`${PROJECTION_END_YEAR}-12-31`);
+    const totalTimeSpan = futureEndDate - firstDate;
+    if (totalTimeSpan <= 0) {
+        container.innerHTML = `<div class="rounded-2xl border border-subtle bg-card-muted py-10 text-center text-muted">Pro vykreslení grafu je potřeba delší časový horizont.</div>`;
+        return;
+    }
+    /* PATCH */
+    const hasIrr = Number.isFinite(portfolioIrr) && activeSet.length > 0;
+    const displayIrr = hasIrr ? portfolioIrr : 0;
+    const dailyRate = Math.pow(1 + displayIrr, 1 / 365.25) - 1;
+    let runningActive = 0;
+    let runningFrozen = 0;
+    let cumulativeContributions = 0;
+    let lastGrowthDate = firstDate;
+    const allPoints = [{ date: firstDate, value: 0, contributions: 0, frozenValue: 0 }];
+    const depositsByDay = new Map();
+    allEvents.forEach(evt => {
+        const daysSinceLast = (evt.date - lastGrowthDate) / MS_PER_DAY;
+        if (daysSinceLast > 0 && hasIrr && runningActive !== 0) {
+            runningActive *= Math.pow(1 + dailyRate, daysSinceLast);
+        }
+        lastGrowthDate = evt.date;
+        const valueBefore = runningActive + runningFrozen;
+        allPoints.push({ date: evt.date, value: valueBefore, contributions: cumulativeContributions, frozenValue: runningFrozen });
+        cumulativeContributions += evt.amount;
+        if (evt.freeze) {
+            runningFrozen += evt.amount;
+        } else {
+            runningActive += evt.amount;
+        }
+        const valueAfter = runningActive + runningFrozen;
+        allPoints.push({ date: evt.date, value: valueAfter, contributions: cumulativeContributions, frozenValue: runningFrozen });
+        const dayKey = evt.date.toISOString().split('T')[0];
+        const dayEntry = depositsByDay.get(dayKey) || { date: evt.date, entries: [], contributions: 0, value: 0, frozenValue: 0 };
+        dayEntry.date = evt.date;
+        dayEntry.contributions = cumulativeContributions;
+        dayEntry.value = valueAfter;
+        dayEntry.frozenValue = runningFrozen;
+        dayEntry.entries.push({ fund: evt.fund, amount: evt.amount, freeze: evt.freeze });
+        depositsByDay.set(dayKey, dayEntry);
+    });
+    const daysToToday = (today - lastGrowthDate) / MS_PER_DAY;
+    if (daysToToday > 0 && hasIrr && runningActive !== 0) {
+        runningActive *= Math.pow(1 + dailyRate, daysToToday);
+    }
+    /* PATCH */
+    const frozenCurrentTotal = Number.isFinite(frozenTotalOption)
+        ? frozenTotalOption
+        : funds.reduce((sum, f) => f.freeze ? sum + (Number.isFinite(convert(f.current, f.curr)) ? convert(f.current, f.curr) : 0) : sum, 0);
+    /* PATCH */
+    const frozenAdjustment = frozenCurrentTotal - runningFrozen;
+    if (frozenAdjustment !== 0) {
+        allPoints.forEach(point => {
+            if (point.frozenValue > 0) {
+                point.value += frozenAdjustment;
+            }
+        });
+        depositsByDay.forEach(entry => {
+            if (entry.frozenValue > 0) {
+                entry.value += frozenAdjustment;
+            }
+        });
+        runningFrozen += frozenAdjustment;
+    }
+    allPoints.sort((a, b) => a.date - b.date);
+    const valueAtToday = runningActive + runningFrozen;
+    allPoints.push({ date: today, value: valueAtToday, contributions: cumulativeContributions, frozenValue: runningFrozen });
+    const projectionPoints = [{ date: today, value: valueAtToday }];
+    if (hasIrr && runningActive !== 0) {
+        let projectedActive = runningActive;
+        let lastProjectionDate = today;
+        for (let year = today.getFullYear() + 1; year <= PROJECTION_END_YEAR; year++) {
+            const nextDate = new Date(`${year}-12-31`);
+            const daysFromLast = (nextDate - lastProjectionDate) / MS_PER_DAY;
+            projectedActive *= Math.pow(1 + dailyRate, daysFromLast);
+            projectionPoints.push({ date: nextDate, value: projectedActive + runningFrozen });
+            lastProjectionDate = nextDate;
+        }
+    }
+    const height = 400;
+    const margin = {top: 20, right: 20, bottom: 60, left: 70};
+    /* PATCH: guard against zero-width containers */
+    const baseWidth = options.isForPdf ? 800 : (container.clientWidth || 0);
+    /* PATCH */
+    const minWidth = margin.left + margin.right + 50;
+    /* PATCH */
+    const width = Math.max(baseWidth, minWidth);
+    const boundedWidth = width - margin.left - margin.right;
+    const boundedHeight = height - margin.top - margin.bottom;
+    const maxContribution = Math.max(...allPoints.map(p => Number.isFinite(p.contributions) ? p.contributions : 0), 0);
+    const maxValue = Math.max(maxContribution, ...allPoints.map(p => p.value), ...projectionPoints.map(p => p.value));
+    const yMax = Math.ceil(maxValue / 100000) * 100000 || 100000;
+    const xScale = (date) => margin.left + ((date - firstDate) / totalTimeSpan) * boundedWidth;
+    const yScale = (value) => margin.top + boundedHeight - (value / yMax) * boundedHeight;
+    const xToDate = (x) => new Date(firstDate.getTime() + ((x - margin.left) / boundedWidth) * totalTimeSpan);
+    const svg = document.createElementNS('http://www.w3.org/2000/svg', 'svg');
+    svg.setAttribute('width', '100%');
+    svg.setAttribute('height', height);
+    svg.setAttribute('viewBox', `0 0 ${width} ${height}`);
+    let innerHTML = '';
+    const yAxisTicks = 5;
+    for (let i = 0; i <= yAxisTicks; i++) {
+      const val = (yMax / yAxisTicks) * i;
+      const y = yScale(val);
+      innerHTML += `<line class="line-chart-grid-line" x1="${margin.left}" y1="${y}" x2="${width - margin.right}" y2="${y}"></line>`;
+      innerHTML += `<text class="line-chart-axis-text" x="${margin.left - 10}" y="${y + 4}" text-anchor="end">${val/1000000} M</text>`;
+    }
+    for (let year = firstDate.getFullYear(); year <= PROJECTION_END_YEAR; year+=2) {
+      if(year < firstDate.getFullYear()) continue;
+      const date = new Date(`${year}-01-01`);
+      const x = xScale(date);
+      innerHTML += `<text class="line-chart-axis-text" x="${x}" y="${height - 25}" text-anchor="middle">${year}</text>`;
+    }
+    const historicalPoints = allPoints.filter(p => p.date <= today);
+    const contributionPath = "M" + historicalPoints.map(p => `${xScale(p.date)},${yScale(p.contributions)}`).join(" L");
+    const valuePath = "M" + historicalPoints.map(p => `${xScale(p.date)},${yScale(p.value)}`).join(" L");
+    const projectionPath = "M" + projectionPoints.map(p => `${xScale(p.date)},${yScale(p.value)}`).join(" L");
+    innerHTML += `<path d="${contributionPath}" fill="none" stroke="rgba(51,55,61,0.55)" stroke-width="2"></path>`;
+    innerHTML += `<path d="${valuePath}" fill="none" stroke="#4DB1C8" stroke-width="2.5"></path>`;
+    innerHTML += `<path d="${projectionPath}" fill="none" stroke="#0d2c54" stroke-width="2.5" stroke-dasharray="5 5"></path>`;
+    const xToday = xScale(today);
+    /* PATCH */
+    const formattedTodayValue = formattedTodayValueOverride ?? formatCurrency0(valueAtToday, outCurr);
+    const snapPoints = [{x: xToday, y: yScale(valueAtToday), date: today, value: valueAtToday, isToday: true}];
+    if (!options.isForPdf) {
+        const dayEntries = Array.from(depositsByDay.values()).sort((a, b) => a.date - b.date);
+        dayEntries.forEach(entry => {
+            const x = xScale(entry.date);
+            const y = yScale(entry.value);
+            const dateLabel = entry.date.toLocaleDateString('cs-CZ');
+            let tooltipText = '';
+            if (entry.entries.length > 1) {
+                tooltipText = `<div class="font-bold text-primary">Vklady (${dateLabel})</div>`
+                    + entry.entries.map(d => `<div class="text-sm text-body">${htmlEscape(d.fund)}: ${formatCurrency0(d.amount, outCurr)}</div>`).join('');
+            } else {
+                const d = entry.entries[0];
+                tooltipText = `<div class="text-primary">Vklad (${htmlEscape(d.fund)}): ${formatCurrency0(d.amount, outCurr)} (${dateLabel})</div>`;
+            }
+            const escapedTooltipText = tooltipText.replace(/"/g, '&quot;');
+            const ariaLabel = entry.entries.length > 1
+                ? `Vklady ${dateLabel}: ${entry.entries.map(d => `${d.fund} ${formatCurrency0(d.amount, outCurr)}`).join(', ')}`
+                : `Vklad ${dateLabel}: ${entry.entries[0].fund} ${formatCurrency0(entry.entries[0].amount, outCurr)}`;
+            innerHTML += `<circle class='line-chart-dot' cx="${x}" cy="${y}" r="4" fill="#4DB1C8" tabindex="0" aria-label="${htmlEscape(ariaLabel)}" data-tooltip-text='${escapedTooltipText}'></circle>`;
+            snapPoints.push({
+                x,
+                y,
+                date: entry.date,
+                value: entry.value,
+                isDeposit: true,
+                tooltipText
+            });
+        });
+    }
+    innerHTML += `<line x1="${xToday}" y1="${margin.top}" x2="${xToday}" y2="${height - margin.bottom}" stroke="#0d2c54" stroke-width="1.5"></line>`;
+    const todayLabel = `Dopočítaná hodnota ke dnešnímu dni dle XIRR: ${formattedTodayValue}`;
+    innerHTML += `<circle class="line-chart-dot line-chart-dot--today" cx="${xToday}" cy="${yScale(valueAtToday)}" r="5" fill="#0d2c54" stroke="white" stroke-width="2" tabindex="0" aria-label="${htmlEscape(todayLabel)}" data-tooltip-text="${htmlEscape(todayLabel)}"></circle>`;
+    innerHTML += `<g transform="translate(${margin.left}, ${height - 10})"><circle cx="0" cy="-4" r="4" fill="#4DB1C8"></circle><text class="line-chart-axis-text" x="10" y="0">Hodnota</text><line x1="65" y1="-4" x2="85" y2="-4" stroke="#4DB1C8" stroke-dasharray="3 3" stroke-width="2"></line><text class="line-chart-axis-text" x="95" y="0">Predikce</text><line x1="160" y1="-4" x2="180" y2="-4" stroke="rgba(51,55,61,0.55)" stroke-width="2"></line><text class="line-chart-axis-text" x="190" y="0">Vklady</text></g>`;
+    const projectValueAt = (targetDate) => {
+        if (!(targetDate instanceof Date) || isNaN(targetDate)) return valueAtToday;
+        if (targetDate <= today) return valueAtToday;
+        if (!hasIrr || runningActive === 0) return valueAtToday;
+        const daysAhead = (targetDate - today) / MS_PER_DAY;
+        return runningFrozen + runningActive * Math.pow(1 + dailyRate, daysAhead);
+    };
+    if (options.isForPdf) {
+        const fixedTooltipPoints = [ { date: today, label: 'Dnes' } ];
+        const endOfYear = new Date(today.getFullYear(), 11, 31);
+        if (endOfYear > today) {
+            fixedTooltipPoints.push({ date: endOfYear, label: endOfYear.getFullYear().toString() });
+        }
+        for (let year = today.getFullYear() + 3; year <= PROJECTION_END_YEAR; year += 3) {
+            const date = new Date(year, 11, 31);
+            if (date <= futureEndDate) {
+                fixedTooltipPoints.push({ date, label: year.toString() });
+            }
+        }
+        fixedTooltipPoints.forEach(point => {
+            const value = projectValueAt(point.date);
+            const x = xScale(point.date);
+            const y = yScale(value);
+            innerHTML += `<g transform="translate(${x}, ${y})">
+                <circle r="5" fill="#0d2c54" stroke="white" stroke-width="2"></circle>
+                <rect x="-40" y="-35" width="80" height="20" rx="5" fill="rgba(255,255,255,0.8)"></rect>
+                <text text-anchor="middle" y="-20" font-size="10px" fill="#1f2937">
+                    <tspan x="0" dy="0">${point.label}: ${formatCurrency0(value, outCurr)}</tspan>
+                </text>
+            </g>`;
+        });
+    }
+    svg.innerHTML = innerHTML;
+    const startLabel = formatDate(firstDate);
+    const endLabel = formatDate(today);
+    const ariaSummary = hasIrr
+        ? `Vývoj portfolia v období ${startLabel} – ${endLabel}; dnešní hodnota ${formattedTodayValue}; XIRR ${formatXirr1(portfolioIrr)}`
+        : `Vývoj portfolia v období ${startLabel} – ${endLabel}; dnešní hodnota ${formattedTodayValue}; XIRR není k dispozici.`;
+    svg.setAttribute('role', 'img');
+    let svgTitle = svg.querySelector('title');
+    if (!svgTitle) {
+        svgTitle = document.createElementNS('http://www.w3.org/2000/svg', 'title');
+        svg.insertBefore(svgTitle, svg.firstChild);
+    }
+    svgTitle.textContent = ariaSummary;
+    if (container) {
+        container.setAttribute('role', 'img');
+        container.setAttribute('aria-label', ariaSummary);
+    }
+    if (!options.isForPdf) {
+        const interactionLayer = document.createElementNS('http://www.w3.org/2000/svg', 'rect');
+        interactionLayer.setAttribute('width', boundedWidth);
+        interactionLayer.setAttribute('height', boundedHeight);
+        interactionLayer.setAttribute('x', margin.left);
+        interactionLayer.setAttribute('y', margin.top);
+        interactionLayer.setAttribute('fill', 'transparent');
+        const guideLine = document.createElementNS('http://www.w3.org/2000/svg', 'line');
+        guideLine.setAttribute('stroke', '#9ca3af');
+        guideLine.setAttribute('stroke-width', '1');
+        guideLine.style.opacity = 0;
+        const guideCircle = document.createElementNS('http://www.w3.org/2000/svg', 'circle');
+        guideCircle.setAttribute('r', '4');
+        guideCircle.setAttribute('fill', '#4b5563');
+        guideCircle.style.opacity = 0;
+        svg.appendChild(guideLine);
+        svg.appendChild(guideCircle);
+        svg.appendChild(interactionLayer);
+        interactionLayer.addEventListener('mousemove', (e) => {
+            const x = e.offsetX;
+            const snapThreshold = 10;
+            let finalX = x, finalY, finalDate, finalValue, tooltipText;
+            let closestSnapPoint = null;
+            let minDistance = snapThreshold;
+            snapPoints.forEach(p => {
+                const dist = Math.abs(x - p.x);
+                if (dist < minDistance) {
+                    minDistance = dist;
+                    closestSnapPoint = p;
+                }
+            });
+            if (closestSnapPoint) {
+                finalX = closestSnapPoint.x;
+                finalY = closestSnapPoint.y;
+                finalDate = closestSnapPoint.date;
+                finalValue = closestSnapPoint.value;
+                if (closestSnapPoint.isToday) {
+                tooltipText = `<div class="font-bold text-primary">Dnes: ${finalDate.toLocaleDateString('cs-CZ')}</div><div class="text-body">Dopočítaná hodnota: ${formatCurrency0(finalValue, outCurr)}</div>`;
+                } else {
+                    tooltipText = closestSnapPoint.tooltipText;
+                }
+            } else {
+                finalDate = xToDate(x);
+                const fullData = [...allPoints.filter(p => p.date <= today), ...projectionPoints];
+                const nextPoint = fullData.find(p => p.date > finalDate);
+                const prevPoint = fullData[fullData.indexOf(nextPoint) - 1];
+                if(prevPoint && nextPoint){
+                    const t = (finalDate - prevPoint.date) / (nextPoint.date - prevPoint.date);
+                    finalValue = prevPoint.value + t * (nextPoint.value - prevPoint.value);
+                } else {
+                    finalValue = allPoints[allPoints.length-1].value;
+                }
+                finalY = yScale(finalValue);
+                tooltipText = `<div class="font-bold text-primary">${finalDate.toLocaleDateString('cs-CZ')}</div><div class="text-body">${formatCurrency0(finalValue, outCurr)}</div>`;
+            }
+            guideLine.setAttribute('x1', finalX);
+            guideLine.setAttribute('y1', finalY);
+            guideLine.setAttribute('x2', finalX);
+            guideLine.setAttribute('y2', height - margin.bottom);
+            guideCircle.setAttribute('cx', finalX);
+            guideCircle.setAttribute('cy', finalY);
+            guideLine.style.opacity = 1;
+            guideCircle.style.opacity = 1;
+            const tooltip = elements.chartTooltip || document.getElementById('chart-tooltip');
+            if (tooltip) {
+                tooltip.innerHTML = tooltipText;
+                tooltip.classList.remove('hidden');
+                tooltip.style.opacity = '1';
+            }
+        });
+        interactionLayer.addEventListener('mouseout', () => {
+            guideLine.style.opacity = 0;
+            guideCircle.style.opacity = 0;
+            const tooltip = elements.chartTooltip || document.getElementById('chart-tooltip');
+            if (tooltip) {
+                tooltip.classList.add('hidden');
+                tooltip.style.opacity = '0';
+            }
+        });
+    }
+    container.appendChild(svg);
+  };
+
+  const setupTimeSlider = (funds) => {
+    const slider = elements.pieSlider || document.getElementById('pie-time-slider');
+    if (!slider) return;
+    const deposits = funds.map(f => f.dateIn).sort((a,b) => a - b);
+    if(deposits.length === 0) return;
+    const firstDate = deposits[0];
+    const endDate = new Date(`${PROJECTION_END_YEAR}-12-31`);
+    const today = new Date();
+    slider.min = firstDate.getTime();
+    slider.max = endDate.getTime();
+    if (!slider.dataset.initialized) {
+        slider.value = today.getTime();
+        slider.dataset.initialized = 'true';
+    }
+    if (elements.sliderStartLabel) {
+        elements.sliderStartLabel.textContent = firstDate.toLocaleDateString('cs-CZ');
+    }
+    if (elements.sliderEndLabel) {
+        elements.sliderEndLabel.textContent = endDate.toLocaleDateString('cs-CZ');
+    }
+    updatePieChartFromSlider();
+  };
+  const updatePieChartFromSlider = () => {
+    /* PATCH */
+    const { funds: allFunds = [] } = state.lastProcessedData;
+    const outCurr = elements.outCurrency?.value || 'CZK';
+    const fxRate = utils.numCZ(elements.fxRate?.value);
+    const slider = elements.pieSlider || document.getElementById('pie-time-slider');
+    if (!slider) return;
+    const convert = (amt, from) => utils.convertAmount(amt, from, outCurr, fxRate);
+    const currentDate = new Date(parseInt(slider.value));
+    if (elements.sliderCurrentLabel) {
+        elements.sliderCurrentLabel.textContent = currentDate.toLocaleDateString('cs-CZ');
+    }
+    /* PATCH */
+    const collection = Array.isArray(allFunds) ? allFunds : [];
+    /* PATCH */
+    const grouped = collection.reduce((acc, fund) => {
+        if (!fund.fund) return acc;
+        if (!acc[fund.fund]) acc[fund.fund] = [];
+        acc[fund.fund].push(fund);
+        return acc;
+    }, {});
+    /* PATCH */
+    const dataForDate = Object.entries(grouped).map(([name, entries]) => {
+        let value = 0;
+        entries.forEach(entry => {
+            if (!(entry.dateIn instanceof Date) || currentDate < entry.dateIn) return;
+            const convertedInvest = convert(entry.invest, entry.curr);
+            const convertedCurrent = convert(entry.current, entry.curr);
+            const hasValuation = entry.currDate instanceof Date && entry.currDate >= entry.dateIn;
+            if (hasValuation && Number.isFinite(convertedCurrent)) {
+                if (entry.freeze) {
+                    value += convertedCurrent;
+                } else if (Number.isFinite(entry.irr)) {
+                    const dailyRate = Math.pow(1 + entry.irr, 1 / 365.25) - 1;
+                    const days = Math.max(0, (currentDate - entry.currDate) / MS_PER_DAY);
+                    value += convertedCurrent * Math.pow(1 + dailyRate, days);
+                } else {
+                    value += convertedCurrent;
+                }
+            } else if (Number.isFinite(convertedInvest)) {
+                value += convertedInvest;
+            }
+        });
+        return { name, totalCurrent: value };
+    }).filter(d => Number.isFinite(d.totalCurrent) && d.totalCurrent > 0);
+    const pieContainer = elements.pieChartContainer || document.getElementById('pie-chart-container');
+    if (pieContainer) {
+        renderPieChart(pieContainer, dataForDate, outCurr);
+    }
+  };
+  const renderPieChart = (container, data, outCurr, options = {}) => {
+    /* PATCH */
+    const { isStaticExport = false, copy: pieCopy = null, format = {}, /* PATCH */ language = 'cs' } = options;
+    /* PATCH */
+    const percentFormat = format.percent || {};
+    const pieTotal = data.reduce((sum, d) => sum + d.totalCurrent, 0);
+
+    if (isStaticExport) {
+        if (!data.length || !(pieTotal > 0)) {
+            /* PATCH */
+            const noDataLabel = pieCopy?.noData || 'Nejsou k dispozici data pro koláčový graf.';
+            return `<div class="rounded-2xl border border-subtle bg-card-muted py-10 text-center text-muted">${htmlEscape(noDataLabel)}</div>`;
+        }
+        const slices = data.map(d => ({ name: d.name, value: d.totalCurrent, color: getColor(d.name) }));
+        /* PATCH */
+        const svg = buildStaticPieChartSvg(slices, pieTotal, outCurr, { copy: pieCopy, format, /* PATCH */ language });
+        /* PATCH */
+        const legend = slices.map(d => `<div class="legend-item"><span class="legend-dot" style="background:${d.color}"></span><span class="legend-name">${htmlEscape(d.name)}</span><span class="legend-value">${formatPercent1(d.value / pieTotal, percentFormat)}</span></div>`).join('');
+        return `<div class="pie-export"><div class="pie-canvas">${svg}</div><div class="pie-legend">${legend}</div></div>`;
+    }
+
+    if (!container) return;
+    container.innerHTML = '';
+    if(data.length === 0) {
+        container.innerHTML = `<div class="text-center py-10 text-muted">Pro zvolené datum nejsou data.</div>`;
+        return;
+    }
+    const svg = document.createElementNS("http://www.w3.org/2000/svg", "svg");
+    svg.setAttribute('viewBox', '0 0 100 100');
+    let angle = -90; const outerRadius = 48; const innerRadius = 24;
+    if (data.length === 1 && pieTotal > 0) {
+        const d = data[0];
+        const g = document.createElementNS("http://www.w3.org/2000/svg", "g");
+        g.classList.add('pie-segment');
+        g.setAttribute('tabindex', '0');
+        g.setAttribute('aria-label', `${d.name}: ${formatCurrency0(d.totalCurrent, outCurr)} (${formatPercent1(d.totalCurrent / pieTotal)})`);
+        g.dataset.name = d.name;
+        g.dataset.value = formatCurrency0(d.totalCurrent, outCurr);
+        g.dataset.percent = formatPercent1(d.totalCurrent / pieTotal);
+        const circle = document.createElementNS("http://www.w3.org/2000/svg", "circle");
+        circle.setAttribute('cx', 50);
+        circle.setAttribute('cy', 50);
+        circle.setAttribute('r', (outerRadius + innerRadius) / 2);
+        circle.setAttribute('stroke', getColor(d.name));
+        circle.setAttribute('stroke-width', outerRadius - innerRadius);
+        circle.setAttribute('fill', 'none');
+        g.appendChild(circle);
+        svg.appendChild(g);
+    } else {
+        data.forEach((d) => {
+            const percent = d.totalCurrent / pieTotal; if (percent === 0) return;
+            const g = document.createElementNS("http://www.w3.org/2000/svg", "g");
+            g.classList.add('pie-segment');
+            g.setAttribute('tabindex', '0');
+            g.setAttribute('aria-label', `${d.name}: ${formatCurrency0(d.totalCurrent, outCurr)} (${formatPercent1(d.totalCurrent / pieTotal)})`);
+            g.dataset.name = d.name; g.dataset.value = formatCurrency0(d.totalCurrent, outCurr); g.dataset.percent = formatPercent1(d.totalCurrent / pieTotal);
+            const startAngleRad = (angle * Math.PI) / 180; angle += percent * 360; const endAngleRad = (angle * Math.PI) / 180;
+            const x1_outer = 50 + outerRadius * Math.cos(startAngleRad); const y1_outer = 50 + outerRadius * Math.sin(startAngleRad);
+            const x2_outer = 50 + outerRadius * Math.cos(endAngleRad); const y2_outer = 50 + outerRadius * Math.sin(endAngleRad);
+            const x1_inner = 50 + innerRadius * Math.cos(startAngleRad); const y1_inner = 50 + innerRadius * Math.sin(startAngleRad);
+            const x2_inner = 50 + innerRadius * Math.cos(endAngleRad); const y2_inner = 50 + innerRadius * Math.sin(endAngleRad);
+            const largeArc = percent > 0.5 ? 1 : 0;
+            const path = document.createElementNS("http://www.w3.org/2000/svg", "path");
+            path.setAttribute('d', `M ${x1_outer},${y1_outer} A ${outerRadius},${outerRadius} 0 ${largeArc},1 ${x2_outer},${y2_outer} L ${x2_inner},${y2_inner} A ${innerRadius},${innerRadius} 0 ${largeArc},0 ${x1_inner},${y1_inner} Z`);
+            path.setAttribute('fill', getColor(d.name)); path.setAttribute('stroke', '#fff'); path.setAttribute('stroke-width', '2');
+            g.appendChild(path); svg.appendChild(g);
+        });
+    }
+    const centerCircle = document.createElementNS("http://www.w3.org/2000/svg", "circle");
+    centerCircle.setAttribute('cx', 50);
+    centerCircle.setAttribute('cy', 50);
+    centerCircle.setAttribute('r', innerRadius - 3);
+    centerCircle.setAttribute('fill', '#ffffff');
+    centerCircle.setAttribute('stroke', '#EAECEE');
+    centerCircle.setAttribute('stroke-width', '2');
+    centerCircle.setAttribute('pointer-events', 'none');
+    svg.appendChild(centerCircle);
+    const legend = data.map(d => `<div class="legend-item"><span class="legend-dot" style="background:${getColor(d.name)}"></span><span class="legend-name">${d.name}</span><span class="legend-value">${formatPercent1(d.totalCurrent / pieTotal)}</span></div>`).join('');
+    container.innerHTML = `<div class="pie-export"><div class="pie-canvas"></div><div class="pie-legend">${legend}</div></div>`;
+    container.querySelector('.pie-canvas').appendChild(svg);
+  };
+
+  const buildStaticPieChartSvg = (slices, total, currency = 'CZK', options = {}) => {
+      /* PATCH */
+      const { copy = {}, format = {} } = options;
+      if (!slices.length || !(total > 0)) return '';
+      const outerRadius = 48;
+      const innerRadius = 24;
+      let angle = -90;
+      const parts = slices.map(({ name, value, color }) => {
+          const percent = value / total;
+          if (percent <= 0) return '';
+          const start = angle;
+          angle += percent * 360;
+          const startRad = (start * Math.PI) / 180;
+          const endRad = (angle * Math.PI) / 180;
+          const largeArc = percent > 0.5 ? 1 : 0;
+          const x1Outer = 50 + outerRadius * Math.cos(startRad);
+          const y1Outer = 50 + outerRadius * Math.sin(startRad);
+          const x2Outer = 50 + outerRadius * Math.cos(endRad);
+          const y2Outer = 50 + outerRadius * Math.sin(endRad);
+          const x1Inner = 50 + innerRadius * Math.cos(startRad);
+          const y1Inner = 50 + innerRadius * Math.sin(startRad);
+          const x2Inner = 50 + innerRadius * Math.cos(endRad);
+          const y2Inner = 50 + innerRadius * Math.sin(endRad);
+          /* PATCH */
+          const amountLabel = formatCurrency0(value, currency, format.currency || {});
+          /* PATCH */
+          const percentLabel = formatPercent1(percent, format.percent || {});
+          /* PATCH */
+          const tooltip = copy?.tooltip
+              ? copy.tooltip(name, amountLabel, percentLabel)
+              : `${name} • ${amountLabel} (${percentLabel})`;
+          return `<g class="pie-slice" tabindex="0" aria-label="${htmlEscape(tooltip)}" data-tooltip-text="${htmlEscape(tooltip)}">
+            <path d="M ${x1Outer},${y1Outer} A ${outerRadius},${outerRadius} 0 ${largeArc},1 ${x2Outer},${y2Outer} L ${x2Inner},${y2Inner} A ${innerRadius},${innerRadius} 0 ${largeArc},0 ${x1Inner},${y1Inner} Z" fill="${color}" stroke="#fff" stroke-width="2" />
+            <title>${htmlEscape(tooltip)}</title>
+          </g>`;
+      }).join('');
+      const backdrop = `<circle cx="50" cy="50" r="${outerRadius}" fill="rgba(240,253,250,0.65)" />`;
+      const inner = `<circle cx="50" cy="50" r="${innerRadius - 3}" fill="#ffffff" stroke="rgba(148,163,184,0.35)" stroke-width="1.5" />`;
+      /* PATCH */
+      const ariaLabel = copy?.ariaLabel || 'Alokace portfolia';
+      return `<svg viewBox="0 0 100 100" role="img" aria-label="${htmlEscape(ariaLabel)}">${backdrop}${parts}${inner}</svg>`;
+  };
+
+  const buildLineChartForExport = (funds, outCurr, fxRate, irr, conversionReady, formattedTodayValueOverride = null, options = {}) => {
+      /* PATCH */
+      const { copy = {}, format = {}, language = 'cs', activeFunds = [], frozenTotal = null } = options;
+      /* PATCH */
+      const currencyFormat = format.currency || {};
+      /* PATCH */
+      const percentFormat = format.percent || {};
+      /* PATCH */
+      const formatDateLocal = (date) => formatDateByLanguage(date, language);
+      if (!conversionReady) {
+          return { available: false, reason: 'conversion' };
+      }
+      const convert = (amt, curr) => utils.convertAmount(amt, curr, outCurr, fxRate);
+      const activeSet = Array.isArray(activeFunds) && activeFunds.length ? activeFunds : funds.filter(f => !f.freeze);
+      const events = funds
+          .map(fund => ({
+              date: fund.dateIn instanceof Date ? fund.dateIn : utils.toDate(fund.dateIn),
+              amount: convert(fund.invest, fund.curr),
+              fund: fund.fund,
+              freeze: !!fund.freeze
+          }))
+          .filter(evt => evt.date instanceof Date && !isNaN(evt.date) && Number.isFinite(evt.amount) && evt.amount !== 0)
+          .sort((a, b) => a.date - b.date);
+      if (!events.length) {
+          return { available: false, reason: 'empty' };
+      }
+
+      const today = new Date();
+      today.setHours(0, 0, 0, 0);
+      const projectionEnd = new Date(`${PROJECTION_END_YEAR}-12-31`);
+      const hasIrr = Number.isFinite(irr) && activeSet.length > 0;
+      const dailyRate = hasIrr ? Math.pow(1 + irr, 1 / 365.25) - 1 : 0;
+      const firstDate = events[0].date;
+      let runningActive = 0;
+      let runningFrozen = 0;
+      let cumulative = 0;
+      let lastGrowthDate = firstDate;
+      const contributionPoints = [{ date: firstDate, value: 0 }];
+      const valuePoints = [{ date: firstDate, value: 0 }];
+      const depositsByDay = new Map();
+
+      events.forEach(evt => {
+          const days = Math.max(0, (evt.date - lastGrowthDate) / MS_PER_DAY);
+          if (hasIrr && days > 0 && runningActive !== 0) {
+              runningActive *= Math.pow(1 + dailyRate, days);
+          }
+          lastGrowthDate = evt.date;
+
+          const valueBefore = runningActive + runningFrozen;
+          valuePoints.push({ date: evt.date, value: valueBefore });
+          contributionPoints.push({ date: evt.date, value: cumulative });
+
+          cumulative += evt.amount;
+          if (evt.freeze) {
+              runningFrozen += evt.amount;
+          } else {
+              runningActive += evt.amount;
+          }
+
+          const valueAfter = runningActive + runningFrozen;
+          valuePoints.push({ date: evt.date, value: valueAfter });
+          contributionPoints.push({ date: evt.date, value: cumulative });
+
+          const key = evt.date.toISOString().split('T')[0];
+          const entry = depositsByDay.get(key) || { date: evt.date, amount: 0, breakdown: [], contributions: 0, value: 0 };
+          entry.date = evt.date;
+          entry.amount += evt.amount;
+          entry.breakdown.push({ fund: evt.fund, amount: evt.amount });
+          entry.contributions = cumulative;
+          entry.value = valueAfter;
+          depositsByDay.set(key, entry);
+      });
+
+      const daysToToday = Math.max(0, (today - lastGrowthDate) / MS_PER_DAY);
+      if (hasIrr && daysToToday > 0 && runningActive !== 0) {
+          runningActive *= Math.pow(1 + dailyRate, daysToToday);
+      }
+
+      const frozenCurrentTotal = Number.isFinite(frozenTotal)
+          ? frozenTotal
+          : funds.reduce((sum, fund) => fund.freeze ? sum + (Number.isFinite(convert(fund.current, fund.curr)) ? convert(fund.current, fund.curr) : 0) : sum, 0);
+      const frozenAdjustment = frozenCurrentTotal - runningFrozen;
+      if (frozenAdjustment !== 0) {
+          valuePoints.forEach(point => { point.value += frozenAdjustment; });
+          depositsByDay.forEach(entry => { entry.value += frozenAdjustment; });
+          runningFrozen += frozenAdjustment;
+      }
+
+      const valueAtToday = runningActive + runningFrozen;
+      contributionPoints.push({ date: today, value: cumulative });
+      valuePoints.push({ date: today, value: valueAtToday });
+
+      const projectionPoints = [];
+      if (hasIrr && runningActive !== 0) {
+          let projectedActive = runningActive;
+          let cursor = today;
+          while (cursor < projectionEnd) {
+              const next = new Date(cursor);
+              next.setFullYear(next.getFullYear() + 1);
+              if (next > projectionEnd) break;
+              const daysAhead = Math.max(0, (next - cursor) / MS_PER_DAY);
+              projectedActive *= Math.pow(1 + dailyRate, daysAhead);
+              projectionPoints.push({ date: next, value: projectedActive + runningFrozen });
+              cursor = next;
+          }
+      }
+
+      const depositPoints = Array.from(depositsByDay.values()).sort((a, b) => a.date - b.date);
+      const irrPositive = projectionPoints.length > 0;
+
+      const timelineEnd = projectionPoints.length ? projectionEnd : today;
+      const span = Math.max(1, timelineEnd - firstDate);
+      const valuesForMax = contributionPoints.map(p => p.value);
+      valuesForMax.push(...valuePoints.map(p => p.value));
+      if (projectionPoints.length) valuesForMax.push(...projectionPoints.map(p => p.value));
+      const yMaxRaw = Math.max(...valuesForMax, 0);
+      const yMax = yMaxRaw > 0 ? Math.ceil(yMaxRaw / 1000) * 1000 : 1000;
+
+      const width = 820;
+      const height = 380;
+      const margin = { top: 32, right: 36, bottom: 78, left: 88 };
+      const chartWidth = width - margin.left - margin.right;
+      const chartHeight = height - margin.top - margin.bottom;
+      const xScale = (date) => margin.left + ((date - firstDate) / span) * chartWidth;
+      const yScale = (value) => margin.top + chartHeight - (value / yMax) * chartHeight;
+      const formatCoord = (value) => Number(value.toFixed(2));
+
+      const pathFromPoints = (points) => points.length ? `M${points.map(p => `${formatCoord(xScale(p.date))},${formatCoord(yScale(p.value))}`).join(' L')}` : '';
+      const contributionsPath = pathFromPoints(contributionPoints);
+      const valuePath = hasIrr ? pathFromPoints(valuePoints) : '';
+      const projectionPath = projectionPoints.length ? pathFromPoints([{ date: today, value: valueAtToday }, ...projectionPoints]) : '';
+      const baselineY = formatCoord(yScale(0));
+      const areaPath = hasIrr && valuePoints.length > 1
+          ? (() => {
+              const coords = valuePoints.map(p => `${formatCoord(xScale(p.date))},${formatCoord(yScale(p.value))}`).join(' L ');
+              const last = valuePoints[valuePoints.length - 1];
+              const firstVal = valuePoints[0];
+              return `M${coords} L${formatCoord(xScale(last.date))},${baselineY} L${formatCoord(xScale(firstVal.date))},${baselineY} Z`;
+          })()
+          : '';
+      const defs = `
+        <defs>
+          <linearGradient id="chartBackdrop" x1="0" y1="0" x2="0" y2="1">
+            <stop offset="0%" stop-color="#f8fafc" />
+            <stop offset="100%" stop-color="#ffffff" />
+          </linearGradient>
+          <linearGradient id="chartValueStroke" x1="0" y1="0" x2="1" y2="0">
+            <stop offset="0%" stop-color="#4DB1C8" />
+            <stop offset="100%" stop-color="#0d2c54" />
+          </linearGradient>
+          <linearGradient id="chartProjectionStroke" x1="0" y1="0" x2="1" y2="0">
+            <stop offset="0%" stop-color="#0d2c54" />
+            <stop offset="100%" stop-color="#A4C4BC" />
+          </linearGradient>
+          <linearGradient id="chartAreaFill" x1="0" y1="0" x2="0" y2="1">
+            <stop offset="0%" stop-color="#4DB1C8" stop-opacity="0.25" />
+            <stop offset="100%" stop-color="#4DB1C8" stop-opacity="0" />
+          </linearGradient>
+        </defs>`;
+      const todayLine = hasIrr ? `<line x1="${formatCoord(xScale(today))}" y1="${margin.top}" x2="${formatCoord(xScale(today))}" y2="${margin.top + chartHeight}" stroke="#4DB1C8" stroke-width="1.5" stroke-dasharray="6 6" stroke-opacity="0.7" />` : '';
+
+      const yTicks = [];
+      const tickCount = 5;
+      for (let i = 0; i <= tickCount; i++) {
+          yTicks.push((yMax / tickCount) * i);
+      }
+
+      const xLabels = [];
+      const startYear = firstDate.getFullYear();
+      const endYear = timelineEnd.getFullYear();
+      const yearSpan = endYear - startYear;
+      const maxTicks = 6;
+      const yearStep = Math.max(1, Math.ceil((yearSpan + 1) / maxTicks));
+      for (let year = startYear; year <= endYear; year += yearStep) {
+          const date = new Date(year, 0, 1);
+          if (date < firstDate) continue;
+          if (date > timelineEnd) break;
+          xLabels.push(date);
+      }
+      if (!xLabels.length || xLabels[xLabels.length - 1].getFullYear() !== endYear) {
+          xLabels.push(new Date(endYear, 0, 1));
+      }
+
+      /* PATCH */
+      const tooltipCopy = copy.tooltip || {};
+      /* PATCH */
+      const formatDepositTooltip = (point) => {
+          const dateLabel = formatDateLocal(point.date);
+          const amountLabel = formatCurrency0(point.amount, outCurr, currencyFormat);
+          if (point.breakdown.length > 1 && tooltipCopy.depositMulti) {
+              const breakdownList = point.breakdown
+                  .map(item => `${item.fund}: ${formatCurrency0(item.amount, outCurr, currencyFormat)}`)
+                  .join(' • ');
+              return tooltipCopy.depositMulti(dateLabel, breakdownList);
+          }
+          if (point.breakdown.length === 1 && tooltipCopy.depositSingle) {
+              const entry = point.breakdown[0];
+              return tooltipCopy.depositSingle(entry.fund, amountLabel, dateLabel);
+          }
+          if (tooltipCopy.generic) {
+              return tooltipCopy.generic(dateLabel, amountLabel);
+          }
+          return `${dateLabel} • ${amountLabel}`;
+      };
+      const depositMarkers = depositPoints.map(point => {
+          const tooltip = formatDepositTooltip(point);
+          /* PATCH: remove native title tooltip, keep aria label for accessibility */
+          return `<circle cx="${formatCoord(xScale(point.date))}" cy="${formatCoord(yScale(hasIrr ? point.value : point.contributions))}" r="4" fill="#0d2c54" stroke="#ffffff" stroke-width="1.5" aria-label="${htmlEscape(tooltip)}" data-tooltip-text="${htmlEscape(tooltip)}"></circle>`;
+      }).join('');
+
+      const projectionMarkers = projectionPoints.map(point => {
+          const dateLabel = formatDateLocal(point.date);
+          const valueLabel = formatCurrency0(point.value, outCurr, currencyFormat);
+          const tooltip = tooltipCopy.projection ? tooltipCopy.projection(dateLabel, valueLabel) : `Odhad ${dateLabel}: ${valueLabel}`;
+          /* PATCH: remove native title tooltip, keep aria label for accessibility */
+          return `<circle cx="${formatCoord(xScale(point.date))}" cy="${formatCoord(yScale(point.value))}" r="4" fill="#4DB1C8" stroke="#ffffff" stroke-width="1.5" aria-label="${htmlEscape(tooltip)}" data-tooltip-text="${htmlEscape(tooltip)}"></circle>`;
+      }).join('');
+
+      /* PATCH */
+      const hoverBase = hasIrr ? [...valuePoints, ...projectionPoints] : contributionPoints;
+      /* PATCH */
+      const hoverPoints = hoverBase.map(point => {
+          const dateLabel = formatDateLocal(point.date);
+          const valueLabel = formatCurrency0(point.value, outCurr, currencyFormat);
+          const tooltip = tooltipCopy.generic
+              ? tooltipCopy.generic(dateLabel, valueLabel)
+              : `${dateLabel}\n${valueLabel}`;
+          return {
+              x: formatCoord(xScale(point.date)),
+              y: formatCoord(yScale(point.value)),
+              tooltip
+          };
+      });
+
+      /* PATCH */
+      const formattedTodayValue = formattedTodayValueOverride || formatCurrency0(valueAtToday, outCurr, currencyFormat);
+      const todayTooltip = tooltipCopy.today
+          ? tooltipCopy.today(formatDateLocal(today), formattedTodayValue)
+          : `Dnes (${formatDateLocal(today)}): ${formattedTodayValue}`;
+      /* PATCH: remove native title tooltip, keep aria label for accessibility */
+      const todayMarker = hasIrr ? `<circle cx="${formatCoord(xScale(today))}" cy="${formatCoord(yScale(valueAtToday))}" r="6" fill="#4DB1C8" stroke="#ffffff" stroke-width="2" aria-label="${htmlEscape(todayTooltip)}" data-tooltip-text="${htmlEscape(todayTooltip)}"></circle>` : '';
+
+      const startLabel = formatDateLocal(firstDate);
+      const endLabel = formatDateLocal(timelineEnd);
+      const ariaLabel = hasIrr
+          ? (copy.aria?.withIrr ? copy.aria.withIrr(startLabel, endLabel, formattedTodayValue, formatXirr1(irr, percentFormat)) : `Vývoj portfolia v období ${startLabel} – ${endLabel}; dnešní hodnota ${formattedTodayValue}; XIRR ${formatXirr1(irr, percentFormat)}`)
+          : (copy.aria?.withoutIrr ? copy.aria.withoutIrr(startLabel, endLabel, formattedTodayValue) : `Vývoj portfolia v období ${startLabel} – ${endLabel}; dnešní hodnota ${formattedTodayValue}; XIRR není k dispozici.`);
+      const svg = `
+        <svg viewBox="0 0 ${width} ${height}">
+          <title>${htmlEscape(ariaLabel)}</title>
+          ${defs}
+          <rect x="0" y="0" width="${width}" height="${height}" fill="url(#chartBackdrop)" rx="26" />
+          <rect x="${margin.left - 8}" y="${margin.top - 12}" width="${chartWidth + 16}" height="${chartHeight + 24}" rx="22" fill="rgba(255,255,255,0.78)" stroke="rgba(148,163,184,0.25)" />
+          ${yTicks.map(tick => {
+              const y = formatCoord(yScale(tick));
+              const tickLabel = formatCurrency0(tick, outCurr, currencyFormat);
+              return `<line x1="${margin.left}" y1="${y}" x2="${width - margin.right}" y2="${y}" stroke="#e5e7eb" stroke-dasharray="4 4" />
+              <text x="${margin.left - 14}" y="${y + 5}" text-anchor="end" font-size="12" fill="#64748b">${tickLabel}</text>`;
+          }).join('')}
+          ${xLabels.map(date => `<text x="${formatCoord(xScale(date))}" y="${height - 24}" text-anchor="middle" font-size="11" fill="#64748b">${date.getFullYear()}</text>`).join('')}
+          ${areaPath ? `<path d="${areaPath}" fill="url(#chartAreaFill)" />` : ''}
+          ${contributionsPath ? `<path d="${contributionsPath}" fill="none" stroke="rgba(51,55,61,0.55)" stroke-width="2.4" stroke-linecap="round" stroke-linejoin="round" />` : ''}
+          ${hasIrr && valuePath ? `<path d="${valuePath}" fill="none" stroke="url(#chartValueStroke)" stroke-width="3" stroke-linecap="round" stroke-linejoin="round" />` : ''}
+          ${irrPositive && projectionPath ? `<path d="${projectionPath}" fill="none" stroke="url(#chartProjectionStroke)" stroke-width="2.5" stroke-dasharray="8 6" stroke-linecap="round" />` : ''}
+          ${todayLine}
+          ${depositMarkers}
+          ${todayMarker}
+            ${projectionMarkers}
+        </svg>
+      `;
+
+      let footnote = '';
+      if (!hasIrr) {
+          footnote = copy.footnotes?.contributionsOnly || 'Graf zachycuje pouze kumulované vklady, protože pro portfolio zatím nelze spolehlivě určit míru XIRR.';
+      } else if (!irrPositive) {
+          footnote = copy.footnotes?.noProjection || 'Odhad aktuální hodnoty vycházejí z vypočtené XIRR, projekce nejsou zobrazeny, protože míra výnosu je nulová nebo záporná.';
+      } else {
+          footnote = copy.footnotes?.default || 'Projekce navazují na aktuální roční míru XIRR. Historické výsledky nejsou zárukou výnosů budoucích.';
+      }
+
+      return {
+          available: true,
+          svg,
+          hasIrr,
+          irrPositive,
+          footnote,
+          ariaLabel,
+          /* PATCH */
+          hoverPoints,
+          /* PATCH */
+          viewBox: { width, height }
+      };
+  };
+
+  /* PATCH */
+  const buildExportCopy = ({ language = 'cs', tone = 'vykani', gender = 'male' }) => {
+      const isEnglish = language === 'en';
+      const isFemale = gender === 'female';
+      const numberLocale = isEnglish ? 'en-GB' : 'cs-CZ';
+      const percentLocale = numberLocale;
+      const monthsLanguage = isEnglish ? 'en' : 'cs';
+
+      if (!isEnglish) {
+          const toneIsInformal = tone === 'tykani';
+          const heroLead = toneIsInformal
+              ? (sal) => `Ahoj ${sal}, připravil jsem pro tebe tento přehledný report, kde jednoduše uvidíš, jak se daří tvým investicím. Věřím, že je vše maximálně srozumitelné, ale pokud budeš mít jakékoli otázky, dej mi prosím vědět – rád vše s tebou projdu osobně.`
+              : (sal) => `Dobrý den, ${sal}, připravil jsem pro Vás tento přehledný report, kde jednoduše uvidíte, jak se daří Vašim investicím. Věřím, že je vše maximálně srozumitelné, ale pokud byste se chtěl${isFemale ? 'a' : ''} na cokoliv zeptat, jsem tu pro Vás.`;
+          const summaryLabels = toneIsInformal
+              ? {
+                  totalInvest: 'TVÉ CELKOVÉ VKLADY',
+                  totalCurrent: 'AKTUÁLNÍ HODNOTA',
+                  totalPnl: 'TVŮJ ČISTÝ VÝNOS',
+                  totalRet: 'CELKOVÉ ZHODNOCENÍ',
+                  irr: 'PRŮMĚRNÝ ROČNÍ VÝNOS (XIRR)',
+                  weightedMonths: 'PRŮMĚRNÁ DOBA INVESTICE'
+              }
+              : {
+                  totalInvest: 'VAŠE CELKOVÉ VKLADY',
+                  totalCurrent: 'AKTUÁLNÍ HODNOTA',
+                  totalPnl: 'ČISTÝ VÝNOS',
+                  totalRet: 'CELKOVÉ ZHODNOCENÍ',
+                  irr: 'PRŮMĚRNÝ ROČNÍ VÝNOS (XIRR)',
+                  weightedMonths: 'PRŮMĚRNÁ DOBA INVESTICE'
+              };
+          return {
+              language: 'cs',
+              htmlLang: 'cs',
+              locale: { date: 'cs-CZ' },
+              format: {
+                  currency: { locale: numberLocale },
+                  percent: { locale: percentLocale },
+                  months: { locale: numberLocale, language: monthsLanguage }
+              },
+              documentTitle: (client) => `Report investičního portfolia – ${client}`,
+              hero: {
+                  badge: 'Klientský report',
+                  title: 'Report investičního portfolia',
+                  lead: heroLead,
+                  meta: {
+                      client: 'Klient',
+                      date: 'DATUM REPORTU',
+                      currency: 'Měna výstupu',
+                      funds: 'Počet fondů',
+                      fx: 'Kurz EUR/CZK'
+                  },
+                  benefits: {
+                      portfolioTitle: 'Diverzifikované portfolio',
+                      portfolioDesc: toneIsInformal
+                          ? 'Tvé investice jsou rozloženy pro optimální růst a bezpečnost.'
+                          : 'Vaše investice jsou rozloženy pro optimální růst a bezpečnost.',
+                      growthTitle: 'Dlouhodobý růst',
+                      growthDesc: toneIsInformal
+                          ? 'Strategie je nastavená s ohledem na dlouhodobé zhodnocení tvého majetku.'
+                          : 'Strategie je nastavena s ohledem na dlouhodobé zhodnocení Vašeho majetku.'
+                  }
+              },
+              narrative: {
+                  pill: 'ÚVOD',
+                  title: toneIsInformal ? 'Vítej ve svém reportu' : 'Vítejte ve Vašem reportu',
+                  body: toneIsInformal
+                      ? 'Na následujících stránkách najdeš klíčové souhrny, detailní pohled na jednotlivé fondy a také výhled do budoucna. Ber to jako takovou „mapu“ naší společné cesty za tvými finančními cíli.'
+                      : 'Na následujících stránkách najdete klíčové souhrny, detailní pohled na jednotlivé fondy a také výhled do budoucna. Berte to jako takovou „mapu“ naší společné cesty za Vašimi finančními cíli.'
+              },
+              summary: {
+                  pill: 'SOUHRN',
+                  title: toneIsInformal ? 'Souhrn tvého portfolia' : 'Souhrn Vašeho portfolia',
+                  body: toneIsInformal
+                      ? 'Klíčové ukazatele, které ti v kostce ukážou celkové zdraví a výkon tvých investic.'
+                      : 'Klíčové ukazatele, které Vám v kostce ukážou celkové zdraví a výkon Vašich investic.',
+                  metaLabel: (currency) => `Částky v ${currency}`,
+                  labels: summaryLabels
+              },
+              funds: {
+                  pill: 'DETAIL FONDŮ',
+                  title: 'Výsledky po fondech',
+                  description: 'Přehled všech sledovaných fondů včetně výkonu, ziskovosti a časové rozlohy investic.',
+                  metrics: {
+                      invested: 'Investováno',
+                      current: 'Aktuální hodnota',
+                      pnl: toneIsInformal ? 'Tvůj čistý výnos' : 'Čistý výnos',
+                      irr: 'Průměrný roční výnos (XIRR)',
+                      months: 'Průměrná doba investice'
+                  },
+                  metaChips: {
+                      transactions: (count) => `Transakcí ${count}`,
+                      valuation: (dateLabel) => `Ocenění ${dateLabel}`,
+                      currency: (currency) => `Cílová měna ${currency}`
+                  },
+                  tableHeaders: {
+                      transaction: 'Transakce',
+                      invested: 'Investice',
+                      pnl: 'Výnos',
+                      current: 'Aktuální hodnota',
+                      months: 'Doba držení',
+                      irr: 'Prům. roční výnos'
+                  },
+                  transactionFirst: 'První vklad',
+                  transactionNext: (index) => `Dokup #${index}`,
+                  showTransactions: 'Zobrazit transakce',
+                  noData: 'Nejsou k dispozici žádná data pro výpočet.'
+              },
+              pie: {
+                  pill: 'ALOKACE',
+                  title: 'Alokace portfolia',
+                  description: 'Rozložení kapitálu mezi jednotlivé fondy k datu exportu.',
+                  noData: 'Pro koláčový graf nejsou dostupná data.',
+                  /* PATCH */
+                  ariaLabel: 'Alokace portfolia',
+                  /* PATCH */
+                  tooltip: (name, amount, percent) => `${name} • ${amount} (${percent})`
+              },
+              line: {
+                  pill: 'VÝVOJ',
+                  title: 'Vývoj hodnoty portfolia',
+                  description: 'Historický vývoj a projekce při zachování aktuální míry zhodnocení portfolia.',
+                  insufficientData: 'Pro vykreslení grafu je potřeba delší časový horizont.',
+                  /* PATCH */
+                  conversion: 'Liniový graf nelze vytvořit bez platného převodu měn.',
+                  /* PATCH */
+                  empty: 'Pro liniový graf nejsou k dispozici údaje.',
+                  /* PATCH */
+                  legend: {
+                      value: 'Odhad hodnoty',
+                      projection: 'Projekce',
+                      contributions: 'Kumulované vklady'
+                  },
+                  /* PATCH */
+                  tooltip: {
+                      depositSingle: (fund, amount, date) => `Vklad (${fund}): ${amount} (${date})`,
+                      depositMulti: (date, list) => `Vklady ${date}: ${list}`,
+                      today: (date, value) => `Dnes: ${date}\nDopočítaná hodnota: ${value}`,
+                      generic: (date, value) => `${date}\n${value}`,
+                      projection: (date, value) => `Odhad ${date}: ${value}`
+                  },
+                  /* PATCH */
+                  aria: {
+                      withIrr: (start, end, todayValue, irrLabel) => `Vývoj portfolia v období ${start} – ${end}; dnešní hodnota ${todayValue}; XIRR ${irrLabel}`,
+                      withoutIrr: (start, end, todayValue) => `Vývoj portfolia v období ${start} – ${end}; dnešní hodnota ${todayValue}; XIRR není k dispozici.`
+                  },
+                  /* PATCH */
+                  footnotes: {
+                      contributionsOnly: 'Graf zachycuje pouze kumulované vklady, protože pro portfolio zatím nelze spolehlivě určit míru XIRR.',
+                      noProjection: 'Odhad aktuální hodnoty vycházejí z vypočtené XIRR, projekce nejsou zobrazeny, protože míra výnosu je nulová nebo záporná.',
+                      default: 'Projekce navazují na aktuální roční míru XIRR. Historické výsledky nejsou zárukou výnosů budoucích.'
+                  }
+              },
+              disclaimers: {
+                  pill: 'POZNÁMKY',
+                  title: 'Důležitá upozornění',
+                  intro: toneIsInformal
+                      ? 'Prosím věnuj pozornost následujícím informacím a limitům výpočtů.'
+                      : 'Prosíme věnujte pozornost následujícím informacím a limitům výpočtů.',
+                  /* PATCH */
+                  listTitle: 'Klíčové poznámky',
+                  items: [
+                      'Historické výnosy nejsou zárukou výsledků budoucích. Projekce vycházejí z aktuálního vývoje portfolia.',
+                      'Veškeré částky platí k datu generování reportu a mohou se v čase měnit podle tržních podmínek.',
+                      'Výpočty vycházejí z dat poskytnutých poradcem; v případě neúplných nebo nepřesných údajů mohou být výsledky zkreslené.'
+                  ]
+              },
+              explanations: {
+                  pill: 'VYSVĚTLIVKY',
+                  title: 'Vysvětlivky a použité metriky',
+                  description: 'Stručná rekapitulace klíčových pojmů pro rychlou orientaci nad výsledky.',
+                  xirr: {
+                      title: 'Co je XIRR a jak funguje?',
+                      body: `Jde o klíčový ukazatel reálné výkonnosti ${toneIsInformal ? 'tvého' : 'Vašeho'} portfolia. Na rozdíl od jednoduchého průměru totiž XIRR spravedlivě zohledňuje, <strong>kdy a jaké částky</strong> jste do portfolia vkládal${isFemale ? 'a' : ''}. Výsledné procento ${toneIsInformal ? 'ti' : 'Vám'} tak dává přesný obraz o tom, jak efektivně ${toneIsInformal ? 'tvoje' : 'Vaše'} peníze v průměru každý rok pracovaly.`
+                  },
+                  cumulative: {
+                      title: 'Co znamená kumulativní zhodnocení?',
+                      body: `Tento údaj ${toneIsInformal ? 'ti' : 'Vám'} poskytuje rychlý a celkový pohled na dosavadní úspěšnost portfolia. Jednoduše řečeno, vyjadřuje ${toneIsInformal ? 'tvůj' : 'Váš'} <strong>celkový čistý výnos jako procento ze všech ${toneIsInformal ? 'tvých' : 'Vašich'} vkladů</strong>. Je to souhrnné číslo, které ukazuje celkový růst od začátku investování až po dnešek.`
+                  }
+              },
+              currencyWarning: (currency) => `Portfolio obsahuje více měn bez zadaného kurzu. Částky nelze spolehlivě převést do ${currency}.`
+          };
+      }
+
+      const heroLead = (sal) => `Hello ${sal}, I’ve prepared this concise report so you can easily see how your investments are performing. I hope everything is perfectly clear, but if you’d like to discuss anything, I’m here for you.`;
+      return {
+          language: 'en',
+          htmlLang: 'en',
+          locale: { date: 'en-GB' },
+          format: {
+              currency: { locale: numberLocale },
+              percent: { locale: percentLocale },
+              months: { locale: numberLocale, language: monthsLanguage }
+          },
+          documentTitle: (client) => `Investment portfolio report – ${client}`,
+          hero: {
+              badge: 'Client report',
+              title: 'Investment portfolio report',
+              lead: heroLead,
+              meta: {
+                  client: 'Client',
+                  date: 'Report date',
+                  currency: 'Reporting currency',
+                  funds: 'Number of funds',
+                  fx: 'EUR/CZK rate'
+              },
+              benefits: {
+                  portfolioTitle: 'Diversified portfolio',
+                  portfolioDesc: 'Your investments are diversified for balanced growth and resilience.',
+                  growthTitle: 'Long-term growth',
+                  growthDesc: 'The strategy is designed to support the long-term appreciation of your wealth.'
+              }
+          },
+          narrative: {
+              pill: 'INTRO',
+              title: 'Welcome to your report',
+              body: 'In the following pages you’ll find key summaries, a detailed look at each fund and a forward-looking projection. Think of it as a map for our shared journey toward your financial goals.'
+          },
+          summary: {
+              pill: 'SUMMARY',
+              title: 'Your portfolio summary',
+              body: 'Key indicators that provide a concise view of the overall health and performance of your investments.',
+              metaLabel: (currency) => `Amounts in ${currency}`,
+              labels: {
+                  totalInvest: 'YOUR TOTAL CONTRIBUTIONS',
+                  totalCurrent: 'CURRENT VALUE',
+                  totalPnl: 'NET GAIN',
+                  totalRet: 'TOTAL RETURN',
+                  irr: 'AVERAGE ANNUAL RETURN (XIRR)',
+                  weightedMonths: 'AVERAGE TIME INVESTED'
+              }
+          },
+          funds: {
+              pill: 'FUND DETAILS',
+              title: 'Fund results',
+              description: 'Overview of each tracked fund including performance, profitability and time in the market.',
+              metrics: {
+                  invested: 'Invested',
+                  current: 'Current value',
+                  pnl: 'Net gain',
+                  irr: 'Average annual return (XIRR)',
+                  months: 'Average holding period'
+              },
+              metaChips: {
+                  transactions: (count) => `Transactions ${count}`,
+                  valuation: (dateLabel) => `Valuation ${dateLabel}`,
+                  currency: (currency) => `Reporting currency ${currency}`
+              },
+              tableHeaders: {
+                  transaction: 'Transaction',
+                  invested: 'Contribution',
+                  pnl: 'Return',
+                  current: 'Current value',
+                  months: 'Holding period',
+                  irr: 'Avg. annual return'
+              },
+              transactionFirst: 'Initial contribution',
+              transactionNext: (index) => `Top-up #${index}`,
+              showTransactions: 'Show transactions',
+              noData: 'No data available for calculation.'
+          },
+          pie: {
+              pill: 'ALLOCATION',
+              title: 'Portfolio allocation',
+              description: 'Distribution of capital across funds at the export date.',
+              noData: 'No allocation data available.',
+              /* PATCH */
+              ariaLabel: 'Portfolio allocation',
+              /* PATCH */
+              tooltip: (name, amount, percent) => `${name} • ${amount} (${percent})`
+          },
+          line: {
+              pill: 'PERFORMANCE',
+              title: 'Portfolio value over time',
+              description: 'Historical performance and a projection assuming the current return rate continues.',
+              insufficientData: 'A longer time horizon is required to draw the chart.',
+              /* PATCH */
+              conversion: 'The line chart cannot be generated without a valid currency conversion.',
+              /* PATCH */
+              empty: 'No data available for the line chart.',
+              /* PATCH */
+              legend: {
+                  value: 'Estimated value',
+                  projection: 'Projection',
+                  contributions: 'Contributions'
+              },
+              /* PATCH */
+              tooltip: {
+                  depositSingle: (fund, amount, date) => `Contribution (${fund}): ${amount} (${date})`,
+                  depositMulti: (date, list) => `Contributions on ${date}: ${list}`,
+                  today: (date, value) => `Today: ${date}\nEstimated value: ${value}`,
+                  generic: (date, value) => `${date}\n${value}`,
+                  projection: (date, value) => `Projection for ${date}: ${value}`
+              },
+              /* PATCH */
+              aria: {
+                  withIrr: (start, end, todayValue, irrLabel) => `Portfolio performance from ${start} to ${end}; today’s estimated value ${todayValue}; XIRR ${irrLabel}`,
+                  withoutIrr: (start, end, todayValue) => `Portfolio performance from ${start} to ${end}; today’s estimated value ${todayValue}; XIRR unavailable.`
+              },
+              /* PATCH */
+              footnotes: {
+                  contributionsOnly: 'The chart shows cumulative contributions only because a reliable XIRR cannot yet be determined.',
+                  noProjection: 'The estimated value is based on the calculated XIRR; projections are hidden because the return is zero or negative.',
+                  default: 'Projections extend the current annual XIRR. Past performance is not a guarantee of future results.'
+              }
+          },
+          disclaimers: {
+              pill: 'NOTES',
+              title: 'Important notes',
+              intro: 'Please review the following information and calculation limits.',
+              /* PATCH */
+              listTitle: 'Key notes',
+              items: [
+                  'Past performance is not a guarantee of future results. Projections are based on the portfolio’s current trajectory.',
+                  'All amounts are valid as of the report date and may change with market conditions.',
+                  'Calculations rely on the information provided; incomplete or inaccurate data may distort the results.'
+              ]
+          },
+          explanations: {
+              pill: 'EXPLANATIONS',
+              title: 'Glossary & metrics',
+              description: 'A quick recap of the key terms to help you navigate the results.',
+              xirr: {
+                  title: 'What is XIRR and how does it work?',
+                  body: 'It is the key measure of your portfolio’s real performance. Unlike a simple average, XIRR fairly considers <strong>when and how much</strong> you contributed. The resulting percentage shows how effectively your money worked on average each year.'
+              },
+              cumulative: {
+                  title: 'What does total return mean?',
+                  body: 'This figure gives you a quick, overall view of the portfolio’s success so far. In short, it expresses your <strong>total net gain as a percentage of all contributions</strong>. It shows the cumulative growth from the start of investing to today.'
+              }
+          },
+          currencyWarning: (currency) => `The portfolio contains multiple currencies without an exchange rate. Values cannot be reliably converted to ${currency}.`
+      };
+  };
+
+  const exportToStaticHTML = () => {
+      const clientName = (state.clientName || '').trim();
+      if (!clientName) {
+          showToast('Před exportem vyplňte jméno klienta.', 'error');
+          elements.clientNameInput?.focus();
+          return;
+      }
+
+      const manualSalutation = (state.clientSalutation || '').trim();
+      const nameParts = parseClientName(clientName);
+      const communicationTone = state.clientTone === 'tykani' ? 'tykani' : 'vykani';
+      /* PATCH */
+      const clientLanguage = state.clientLanguage === 'en' ? 'en' : 'cs';
+      /* PATCH */
+      const clientGender = state.clientGender === 'female' ? 'female' : 'male';
+      const salutation = formatSalutation({
+          firstName: nameParts.firstName,
+          lastName: nameParts.lastName,
+          tone: communicationTone,
+          manualSalutation,
+          /* PATCH */ gender: clientGender,
+          /* PATCH */ language: clientLanguage
+      });
+      if (!salutation) {
+          showToast('Před exportem vyplňte oslovení klienta.', 'error');
+          elements.clientSalutationInput?.focus();
+          return;
+      }
+
+      if (document.activeElement && document.activeElement.isContentEditable) {
+          document.activeElement.blur();
+      }
+
+      const snapshot = processAllRows();
+      const outCurr = elements.outCurrency?.value || 'CZK';
+      const fxRate = utils.numCZ(elements.fxRate?.value);
+      const hasValidFx = Number.isFinite(fxRate) && fxRate > 0;
+      const conversionReady = !(snapshot.hasMixedCurrencies && !hasValidFx);
+
+      if (!snapshot.funds.length) {
+          showToast('Pro export je potřeba zadat alespoň jeden platný fond.', 'error');
+          return;
+      }
+
+      /* PATCH */
+      const copy = buildExportCopy({ language: clientLanguage, tone: communicationTone, gender: clientGender });
+      /* PATCH */
+      const heroLeadText = copy.hero.lead(salutation);
+
+      /* PATCH */
+      const formattedOverrides = {
+          totalCurrent: formatCurrency0(snapshot.portfolioSummary.totalCurrentConverted, outCurr, copy.format.currency)
+      };
+      /* PATCH */
+      const summaryBlock = renderSummary(snapshot.portfolioSummary, outCurr, {
+          isStaticExport: true,
+          formattedTotals: formattedOverrides,
+          tone: communicationTone,
+          /* PATCH */ summaryLabels: copy.summary.labels,
+          /* PATCH */ format: copy.format,
+          /* PATCH */ language: copy.language
+      });
+
+      /* PATCH */
+      const groupedFunds = snapshot.funds.reduce((acc, fund) => {
+          if (!fund.fund) return acc;
+          if (!acc[fund.fund]) acc[fund.fund] = [];
+          acc[fund.fund].push(fund);
+          return acc;
+      }, {});
+
+      const fundsBlock = renderFundsByCard(groupedFunds, outCurr, fxRate, { isStaticExport: true, /* PATCH */ copy: copy.funds, /* PATCH */ format: copy.format, /* PATCH */ language: copy.language });
+
+      /* PATCH */
+      const convert = (amt, curr) => utils.convertAmount(amt, curr, outCurr, fxRate);
+      /* PATCH */
+      const allocationData = Object.entries(groupedFunds).map(([name, entries]) => {
+          const totalCurrent = entries.reduce((sum, entry) => {
+              const converted = convert(entry.current, entry.curr);
+              return Number.isFinite(converted) ? sum + converted : sum;
+          }, 0);
+          return { name, totalCurrent };
+      }).filter(item => item.totalCurrent > 0);
+
+      const pieBlock = allocationData.length
+          ? renderPieChart(null, allocationData, outCurr, { isStaticExport: true, /* PATCH */ copy: copy.pie, /* PATCH */ format: copy.format, /* PATCH */ language: copy.language })
+          : `<div class="rounded-2xl border border-subtle bg-card-muted py-6 text-center text-muted">${htmlEscape(copy.pie.noData)}</div>`;
+
+      const frozenForExport = (snapshot.portfolioSummary.totalCurrentConverted || 0) - (snapshot.portfolioSummary.totalCurrentActive || 0);
+      const lineBlock = renderLineChart(null, snapshot.funds || [], snapshot.portfolioSummary.portfolioIrr, outCurr, fxRate, {
+        isStaticExport: true,
+        conversionReady,
+        /* PATCH */ copy: copy.line,
+        /* PATCH */ format: copy.format,
+        /* PATCH */ language: copy.language,
+        /* PATCH */ activeFunds: snapshot.activeFunds || [],
+        /* PATCH */ frozenTotal: frozenForExport
+      });
+
+      const explanationsBlock = `<div class="export-explanations">
+        <article>
+          <h3>${htmlEscape(copy.explanations.xirr.title)}</h3>
+          <p>${copy.explanations.xirr.body}</p>
+        </article>
+        <article>
+          <h3>${htmlEscape(copy.explanations.cumulative.title)}</h3>
+          <p>${copy.explanations.cumulative.body}</p>
+        </article>
+      </div>`;
+
+      const rawStyle = document.querySelector('style')?.textContent || '';
+      const styleContent = `@import url('https://fonts.googleapis.com/css2?family=Montserrat:wght@400;500;600;700&display=swap');\n${rawStyle.replace(/@import[^;]+;\s*/g, '')}`;
+      /* PATCH */
+      const generatedAt = new Date();
+      /* PATCH */
+      const generatedTimestamp = generatedAt.getTime();
+      /* PATCH */
+      const generatedDateLabel = generatedAt.toLocaleDateString(copy.locale.date);
+      const fundCount = Object.keys(groupedFunds).length;
+      const currencyWarning = (!conversionReady && snapshot.hasMixedCurrencies)
+          ? `<div class="alert">${htmlEscape(copy.currencyWarning(outCurr))}</div>`
+          : '';
+
+      const narrativeSection = `<section class="narrative">
+        <span class="pill">${htmlEscape(copy.narrative.pill)}</span>
+        <h2>${htmlEscape(copy.narrative.title)}</h2>
+        <p>${htmlEscape(copy.narrative.body)}</p>
+      </section>`;
+
+      const summarySection = `<section class="card">
+        <div class="section-heading">
+          <span class="pill">${htmlEscape(copy.summary.pill)}</span>
+          <h2>${htmlEscape(copy.summary.title)}</h2>
+          <p class="section-meta">${htmlEscape(copy.summary.metaLabel(outCurr))}</p>
+          <p>${htmlEscape(copy.summary.body)}</p>
+        </div>
+        ${summaryBlock}
+      </section>`;
+
+      const fundsSection = `<section class="card">
+        <div class="section-heading">
+          <span class="pill">${htmlEscape(copy.funds.pill)}</span>
+          <h2>${htmlEscape(copy.funds.title)}</h2>
+          <p class="section-meta">${htmlEscape(copy.summary.metaLabel(outCurr))}</p>
+          <p>${htmlEscape(copy.funds.description)}</p>
+        </div>
+        <div class="fund-export-grid">${fundsBlock}</div>
+      </section>`;
+
+      const pieSection = `<section class="card">
+        <div class="section-heading">
+          <span class="pill">${htmlEscape(copy.pie.pill)}</span>
+          <h2>${htmlEscape(copy.pie.title)}</h2>
+          <p>${htmlEscape(copy.pie.description)}</p>
+        </div>
+        ${pieBlock}
+      </section>`;
+
+      const lineSection = `<section class="card">
+        <div class="section-heading">
+          <span class="pill">${htmlEscape(copy.line.pill)}</span>
+          <h2>${htmlEscape(copy.line.title)}</h2>
+          <p>${htmlEscape(copy.line.description)}</p>
+        </div>
+        ${lineBlock}
+      </section>`;
+
+      const disclaimerSection = `<section class="card">
+        <div class="section-heading">
+          <span class="pill">${htmlEscape(copy.disclaimers.pill)}</span>
+          <h2>${htmlEscape(copy.disclaimers.title)}</h2>
+          <p>${htmlEscape(copy.disclaimers.intro)}</p>
+        </div>
+        <div class="disclaimer-block">
+          <h3 class="disclaimer-title">${htmlEscape(copy.disclaimers.listTitle || 'Klíčové poznámky')}</h3>
+          <ul class="disclaimer-list">${copy.disclaimers.items.map(item => `<li class="disclaimer-item">${htmlEscape(item)}</li>`).join('')}</ul>
+        </div>
+      </section>`;
+
+      const explanationsSection = `<section class="card">
+        <div class="section-heading">
+          <span class="pill">${htmlEscape(copy.explanations.pill)}</span>
+          <h2>${htmlEscape(copy.explanations.title)}</h2>
+          <p>${htmlEscape(copy.explanations.description)}</p>
+        </div>
+        ${explanationsBlock}
+      </section>`;
+
+      /* PATCH */
+      const footerSection = `<footer class="export-footer"><p class="footer-note">© <span id="year"></span> Ondřej Lacina</p></footer>`;
+
+      const fxMeta = Number.isFinite(fxRate) && fxRate > 0
+          ? `<div class="export-hero__meta-item"><span class="meta-label">${htmlEscape(copy.hero.meta.fx)}</span><span class="meta-value">${formatFxRate(fxRate)}</span></div>`
+          : '';
+
+      const heroSection = `<header class="export-hero">
+        <div class="export-hero__layout">
+          <div class="export-hero__content">
+            <div class="brand-logo">Fair<span>Life</span></div>
+            <span class="export-hero__badge">${htmlEscape(copy.hero.badge)}</span>
+            <h1 class="export-hero__title">${htmlEscape(copy.hero.title)}</h1>
+            <p class="export-hero__lead">${htmlEscape(heroLeadText)}</p>
+            <div class="export-hero__meta">
+              <div class="export-hero__meta-item"><span class="meta-label">${htmlEscape(copy.hero.meta.client)}</span><span class="meta-value">${htmlEscape(clientName)}</span></div>
+              <!-- /* PATCH */ -->
+              <div class="export-hero__meta-item"><span class="meta-label">${htmlEscape(copy.hero.meta.date)}</span><span class="meta-value"><span id="report-date" data-ts="${generatedTimestamp}" data-locale="${copy.locale.date}">${htmlEscape(generatedDateLabel)}</span></span></div>
+              <div class="export-hero__meta-item"><span class="meta-label">${htmlEscape(copy.hero.meta.currency)}</span><span class="meta-value">${htmlEscape(outCurr)}</span></div>
+              <div class="export-hero__meta-item"><span class="meta-label">${htmlEscape(copy.hero.meta.funds)}</span><span class="meta-value">${fundCount}</span></div>
+              ${fxMeta}
+            </div>
+          </div>
+          <div class="export-hero__features">
+            <div class="feature-card benefit">
+              <div class="feature-text">
+                <span class="feature-title benefit-title">${htmlEscape(copy.hero.benefits.portfolioTitle)}</span>
+                <span class="feature-desc benefit-desc">${htmlEscape(copy.hero.benefits.portfolioDesc)}</span>
+              </div>
+            </div>
+            <div class="feature-card benefit">
+              <div class="feature-text">
+                <span class="feature-title benefit-title">${htmlEscape(copy.hero.benefits.growthTitle)}</span>
+                <span class="feature-desc benefit-desc">${htmlEscape(copy.hero.benefits.growthDesc)}</span>
+              </div>
+            </div>
+          </div>
+        </div>
+      </header>`;
+
+      /* PATCH */
+      const reportDateScript = "(function(){var el=document.getElementById('report-date');if(!el)return;var locale=el.getAttribute('data-locale')||'cs-CZ';var src=el.getAttribute('data-ts');var d=src?new Date(Number(src)||src):new Date();if(isNaN(d))d=new Date();el.textContent=d.toLocaleDateString(locale);})();";
+      /* PATCH */
+      const footerYearScript = "(function(){var y=document.getElementById('year');if(y)y.textContent=new Date().getFullYear();})();";
+      const tooltipScript = `document.addEventListener('DOMContentLoaded',()=>{const tooltip=document.createElement('div');tooltip.style.position='fixed';tooltip.style.pointerEvents='none';tooltip.style.padding='0.4rem 0.6rem';tooltip.style.background='rgba(15,23,42,0.92)';tooltip.style.color='#f8fafc';tooltip.style.fontSize='0.75rem';tooltip.style.borderRadius='0.5rem';tooltip.style.opacity='0';tooltip.style.transition='opacity 0.15s ease';tooltip.style.zIndex='50';document.body.appendChild(tooltip);let active=false;const move=e=>{if(!active)return;tooltip.style.left=e.clientX+12+'px';tooltip.style.top=e.clientY+12+'px';};const hide=()=>{active=false;tooltip.style.opacity='0';};document.addEventListener('mousemove',move);document.addEventListener('mouseover',e=>{const target=e.target.closest('[data-tooltip-text]');if(!target)return;tooltip.textContent=target.getAttribute('data-tooltip-text')||'';tooltip.style.left=e.clientX+12+'px';tooltip.style.top=e.clientY+12+'px';tooltip.style.opacity='1';active=true;});document.addEventListener('mouseout',e=>{if(!e.target.closest('[data-tooltip-text]'))return;hide();});const attachLineCharts=()=>{document.querySelectorAll('.line-canvas[data-line-points]').forEach(canvas=>{const raw=canvas.getAttribute('data-line-points');let pts;try{pts=JSON.parse(raw);}catch(_e){return;}if(!pts||!pts.length)return;const svg=canvas.querySelector('svg');if(!svg)return;const vbAttr=(canvas.getAttribute('data-viewbox')||svg.getAttribute('viewBox')||'820 380').split(/[,\s]+/);const vbW=parseFloat(vbAttr[0])||820;const vbH=parseFloat(vbAttr[1])||380;const ns='http://www.w3.org/2000/svg';const guide=document.createElementNS(ns,'g');guide.setAttribute('class','line-hover');guide.style.display='none';const gl=document.createElementNS(ns,'line');gl.setAttribute('stroke','#94a3b8');gl.setAttribute('stroke-width','1');gl.setAttribute('stroke-dasharray','4 3');const gc=document.createElementNS(ns,'circle');gc.setAttribute('r','5');gc.setAttribute('fill','#0d2c54');gc.setAttribute('stroke','#ffffff');gc.setAttribute('stroke-width','2');guide.appendChild(gl);guide.appendChild(gc);svg.appendChild(guide);const hideGuide=()=>{guide.style.display='none';hide();};const showPoint=(pt)=>{guide.style.display='block';gl.setAttribute('x1',pt.x);gl.setAttribute('x2',pt.x);gl.setAttribute('y1',pt.y);gl.setAttribute('y2',vbH-32);gc.setAttribute('cx',pt.x);gc.setAttribute('cy',pt.y);tooltip.textContent=pt.tooltip||'';tooltip.style.opacity='1';active=true;};canvas.addEventListener('mousemove',ev=>{const rect=svg.getBoundingClientRect();const scaleX=vbW/rect.width;const scaleY=vbH/rect.height;const x=(ev.clientX-rect.left)*scaleX;let best=pts[0];let dist=Math.abs(best.x-x);for(let i=1;i<pts.length;i++){const dx=Math.abs(pts[i].x-x);if(dx<dist){dist=dx;best=pts[i];}}tooltip.style.left=ev.clientX+12+'px';tooltip.style.top=ev.clientY+12+'px';showPoint(best);});canvas.addEventListener('mouseleave',hideGuide);canvas.addEventListener('blur',hideGuide,{capture:true});});};attachLineCharts();});`;
+      /* PATCH */
+      const scriptBundle = `${reportDateScript}${footerYearScript}${tooltipScript}`;
+
+      const html = `<!doctype html>
+<html lang="${copy.htmlLang}">
+<head>
+  <meta charset="utf-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <title>${htmlEscape(copy.documentTitle(clientName))}</title>
+  <style>${styleContent}</style>
+</head>
+<body>
+  <div class="export-shell">
+    ${heroSection}
+    ${currencyWarning}
+    ${narrativeSection}
+    ${summarySection}
+    ${fundsSection}
+    ${pieSection}
+    ${lineSection}
+    ${disclaimerSection}
+    ${explanationsSection}
+    ${footerSection}
+  </div>
+  <script>${scriptBundle}${SCRIPT_CLOSE_TAG}
+</body>
+</html>`;
+
+      const blob = new Blob([html], { type: 'text/html' });
+      const url = URL.createObjectURL(blob);
+      const anchor = document.createElement('a');
+      const safeName = clientName.toLowerCase().replace(/[^\p{L}\p{N}\s-]+/gu, '').trim().replace(/\s+/g, '-');
+      anchor.href = url;
+      anchor.download = `report-${safeName || 'klient'}-${generatedAt.toISOString().split('T')[0]}.html`;
+      document.body.appendChild(anchor);
+      anchor.click();
+      document.body.removeChild(anchor);
+      URL.revokeObjectURL(url);
+      showToast('Report byl exportován.');
+  };
+
+  const calculateAnnuity = () => {
+      const { portfolioSummary, activeFunds } = state.lastProcessedData;
+      const { portfolioIrr, totalCurrentActive } = portfolioSummary;
+      const monthlyAnnuity = utils.numCZ(elements.annuityInput?.value);
+      const resultDiv = elements.annuityResult || document.getElementById('annuity-result');
+      const annualDiv = elements.annuityAnnual || document.getElementById('annuity-annual-equivalent');
+      const disclaimer = elements.annuityDisclaimer || document.getElementById('annuity-disclaimer');
+      if (!resultDiv || !annualDiv || !disclaimer) {
+          return;
+      }
+      if (!isFinite(monthlyAnnuity) || monthlyAnnuity <= 0) {
+          resultDiv.style.display = 'none';
+          annualDiv.textContent = '';
+          disclaimer.style.display = 'none';
+          return;
+      }
+      disclaimer.style.display = 'block';
+      const annualAnnuity = monthlyAnnuity * 12;
+      annualDiv.textContent = `(což odpovídá ${formatCurrency0(annualAnnuity, 'CZK', { withUnit: true })} ročně)`;
+      const activeList = Array.isArray(activeFunds) ? activeFunds : [];
+      if (!isFinite(portfolioIrr) || portfolioIrr <= 0 || activeList.length === 0) {
+          resultDiv.innerHTML = 'Pro výpočet renty je potřeba mít v portfoliu data s kladným zhodnocením (XIRR).';
+          resultDiv.style.display = 'block';
+          return;
+      }
+      const targetCapital = annualAnnuity / portfolioIrr;
+      if (totalCurrentActive >= targetCapital) {
+          resultDiv.innerHTML = `<strong>Gratulujeme!</strong> Vaše portfolio s aktuální hodnotou <strong>${formatCurrency0(totalCurrentActive, 'CZK', { withUnit: true })}</strong> je již nyní dostatečně velké, aby generovalo požadovanou roční rentu.`;
+          resultDiv.style.display = 'block';
+          return;
+      }
+      const dailyRate = Math.pow(1 + portfolioIrr, 1 / 365.25) - 1;
+      let days = 0;
+      let futureValue = totalCurrentActive;
+      for (let i = 0; i < 365 * 100; i++) {
+          futureValue *= (1 + dailyRate);
+          days++;
+          if (futureValue >= targetCapital) break;
+      }
+      if (futureValue < targetCapital) {
+          resultDiv.innerHTML = `Při současném tempu růstu se Vám nepodaří dosáhnout cílové částky v rozumném časovém horizontu.`;
+          resultDiv.style.display = 'block';
+          return;
+      }
+      const targetDate = new Date();
+      targetDate.setDate(targetDate.getDate() + days);
+      const monthNames = ["ledna", "února", "března", "dubna", "května", "června", "července", "srpna", "září", "října", "listopadu", "prosince"];
+      const formattedDate = `${monthNames[targetDate.getMonth()]} ${targetDate.getFullYear()}`;
+      resultDiv.innerHTML = `Pro měsíční rentu <strong>${formatCurrency0(monthlyAnnuity, 'CZK', { withUnit: true })}</strong> potřebujete kapitál o velikosti přibližně <strong>${formatCurrency0(targetCapital, 'CZK', { withUnit: true })}</strong>. Při současném tempu růstu byste této částky mohli dosáhnout okolo <strong>${formattedDate}</strong>.`;
+      resultDiv.style.display = 'block';
+  };
+
+  const handleInputChange = (e) => {
+    const target = e.target;
+    const key = target.dataset.key;
+    if (!key) return;
+    const tr = target.closest('tr');
+    if (!tr) return;
+    const id = parseInt(tr.dataset.id, 10);
+    const providerKey = tr.closest('tbody').dataset.tbodyFor;
+    const row = state.rows[providerKey].find(r => r.id === id);
+    if (!row) return;
+    if (target.type === 'checkbox') {
+        row[key] = target.checked;
+    } else {
+        row[key] = target.isContentEditable ? target.textContent : target.value;
+    }
+    if (['invest', 'qty', 'issueNav', 'currNav', 'totalCurrent'].includes(key)) {
+        const p = parseRow(row);
+        if (isFinite(p.invest) && isFinite(p.issueNav) && p.issueNav > 0 && (!row.qty || utils.numCZ(row.qty) <= 0)) {
+            row.qty = String(p.invest / p.issueNav);
+            tr.querySelector('[data-key="qty"]').value = row.qty;
+        } else if (isFinite(p.qty) && isFinite(p.issueNav) && p.qty > 0 && (!row.invest || utils.numCZ(row.invest) <= 0)) {
+            row.invest = String(p.qty * p.issueNav);
+            tr.querySelector('[data-key="invest"]').value = row.invest;
+        }
+        if (isFinite(p.qty) && isFinite(p.currNav) && p.currNav > 0 && (!row.totalCurrent || utils.numCZ(row.totalCurrent) <= 0)) {
+             row.totalCurrent = String(p.qty * p.currNav);
+             tr.querySelector('[data-key="totalCurrent"]').value = row.totalCurrent;
+        }
+    }
+    updateInputHighlights(tr, row);
+    scheduleRecalc();
+    saveState();
+  };
+
+  const updateInputHighlights = (tr, row) => {
+      const parsed = parseRow(row || {});
+      const fields = ['invest', 'dateIn', 'qty', 'issueNav', 'currNav', 'totalCurrent', 'currDate'];
+      fields.forEach(field => {
+          const input = tr.querySelector(`[data-key="${field}"]`);
+          if (input) input.classList.remove('input-highlight');
+      });
+      if (!parsed || !parsed.fund) {
+          return;
+      }
+      const markMissing = (...keys) => {
+          keys.forEach(field => {
+              const input = tr.querySelector(`[data-key="${field}"]`);
+              if (!input) return;
+              const currentValue = row?.[field];
+              if (currentValue === undefined || String(currentValue).trim() === '') {
+                  input.classList.add('input-highlight');
+              }
+          });
+      };
+      if (!parsed.dateIn) markMissing('dateIn');
+      if (!parsed.currDate) markMissing('currDate');
+      const hasInvest = Number.isFinite(parsed.invest) && parsed.invest > 0;
+      const hasQty = Number.isFinite(parsed.qty) && parsed.qty > 0;
+      const hasIssueNav = Number.isFinite(parsed.issueNav) && parsed.issueNav > 0;
+      const hasCurrent = Number.isFinite(parsed.totalCurrent);
+      const hasNav = Number.isFinite(parsed.currNav) && parsed.currNav > 0;
+      if (!hasInvest && !hasQty) {
+          markMissing('invest');
+      } else if (!hasInvest && hasQty && !hasIssueNav) {
+          markMissing('issueNav');
+      }
+      if (!hasCurrent && !hasNav) {
+          markMissing('currNav', 'totalCurrent');
+      }
+  };
+
+  const init = () => {
+    elements.fxRate = document.getElementById('fx-rate');
+    elements.outCurrency = document.getElementById('out-curr');
+    elements.statusContainer = document.getElementById('status-container');
+    elements.toastContainer = document.getElementById('toast-container');
+    elements.lastSavedIndicator = document.getElementById('last-saved-indicator');
+    elements.providerSections = document.getElementById('provider-sections');
+    elements.fundsContainer = document.getElementById('funds-by-card-container');
+    elements.amountNoteFunds = document.getElementById('amount-note-funds');
+    elements.portfolioSummary = document.getElementById('portfolio-summary-content');
+    elements.amountNotePortfolio = document.getElementById('amount-note-portfolio');
+    elements.lineChartCard = document.getElementById('line-chart-card');
+    elements.pieChartCard = document.getElementById('pie-chart-card');
+    elements.chartsSection = document.getElementById('charts-section');
+    elements.lineChartContainer = document.getElementById('line-chart-container');
+    elements.pieChartContainer = document.getElementById('pie-chart-container');
+    elements.pieSlider = document.getElementById('pie-time-slider');
+    elements.sliderStartLabel = document.getElementById('slider-start-date-label');
+    elements.sliderCurrentLabel = document.getElementById('slider-current-date-label');
+    elements.sliderEndLabel = document.getElementById('slider-end-date-label');
+    elements.annuityInput = document.getElementById('annuity-input');
+    elements.annuityAnnual = document.getElementById('annuity-annual-equivalent');
+    elements.annuityResult = document.getElementById('annuity-result');
+    elements.annuityDisclaimer = document.getElementById('annuity-disclaimer');
+    elements.chartTooltip = document.getElementById('chart-tooltip');
+    elements.importFile = document.getElementById('import-file-input');
+    elements.clientNameInput = document.getElementById('client-name');
+    elements.clientSalutationInput = document.getElementById('client-salutation');
+    elements.clientToneInputs = Array.from(document.querySelectorAll('input[name="client-tone"]'));
+    /* PATCH */
+    elements.clientGenderInputs = Array.from(document.querySelectorAll('input[name="client-gender"]'));
+    /* PATCH */
+    elements.clientLanguageInputs = Array.from(document.querySelectorAll('input[name="client-language"]'));
+    if (elements.clientNameInput) {
+        elements.clientNameInput.value = state.clientName;
+    }
+    if (elements.clientSalutationInput) {
+        elements.clientSalutationInput.value = state.clientSalutation;
+    }
+    /* PATCH */
+    updateGenderInputs();
+    updateToneInputs();
+    /* PATCH */
+    updateLanguageInputs();
+    const currentYearEl = document.getElementById('current-year');
+    if (currentYearEl) {
+        currentYearEl.textContent = new Date().getFullYear();
+    }
+    const providerContainer = elements.providerSections;
+    if (providerContainer) {
+        Object.keys(PROVIDERS).forEach(key => providerContainer.appendChild(createProviderSection(key)));
+    }
+    document.addEventListener('click', (e) => {
+        const button = e.target.closest('button[data-action]'); if (!button) return;
+        const { action, provider, id } = button.dataset;
+        if (action === 'add-row') { const newId = ++rowSeq; state.rows[provider].push({ id: newId, fund: '', curr: 'CZK', freeze: false }); renderProviderInputs(provider, newId); }
+        if (action === 'delete-row') { const rowElement = button.closest('tr'); rowElement.className = 'fade-out'; rowElement.addEventListener('animationend', () => { state.rows[provider] = state.rows[provider].filter(r => r.id !== parseInt(id,10)); rowElement.remove(); scheduleRecalc(); saveState(); }); }
+        if (action === 'delete-all') { if (confirm(`Opravdu chcete smazat všechny řádky pro ${PROVIDERS[provider]}?`)) { state.rows[provider] = []; renderProviderInputs(provider); scheduleRecalc(); saveState(); } }
+        /* PATCH */
+        if (action === 'toggle-freeze') {
+            const targetId = parseInt(id, 10);
+            const list = state.rows[provider];
+            const row = list.find(r => r.id === targetId);
+            if (row) {
+                row.freeze = !row.freeze;
+                renderProviderInputs(provider);
+                scheduleRecalc();
+                saveState();
+            }
+        }
+        if (action === 'export-json') exportState();
+        if (action === 'import-json') elements.importFile?.click();
+        if (action === 'export-html') exportToStaticHTML();
+        if (action === 'add-sample') {
+            const today = new Date().toISOString().split('T')[0];
+            const SAMPLES = {
+                avant: [ { id: ++rowSeq, fund: 'r2p invest SICAV, a.s.', invest: '100000', dateIn: '15.03.2021', issueNav: '1.05', currNav: '1.25', currDate: today, curr: 'CZK', freeze: false } ],
+                codya: [ { id: ++rowSeq, fund: 'CODYA Real Estate Fund', invest: '250000', dateIn: '20.11.2020', issueNav: '10.0', currNav: '14.2', currDate: today, curr: 'CZK', freeze: false }, { id: ++rowSeq, fund: 'CODYA Opportunity', invest: '120000', dateIn: '10.01.2023', issueNav: '100', currNav: '118', currDate: today, curr: 'CZK', freeze: false } ],
+                atris: [ { id: ++rowSeq, fund: 'ATRIS Global Equities', invest: '15000', dateIn: '30.05.2022', issueNav: '150', currNav: '195', currDate: today, curr: 'EUR', freeze: false } ],
+                jt: [ { id: ++rowSeq, fund: 'J&T Opportunity CZK', invest: '500000', dateIn: '01.07.2019', issueNav: '1.0', currNav: '1.48', currDate: today, curr: 'CZK', freeze: false } ]
+            };
+            const sampleData = SAMPLES[provider].map(s => ({...s, qty: '', totalCurrent: ''}));
+            state.rows[provider].push(...sampleData);
+            renderProviderInputs(provider); scheduleRecalc(); showToast(`Ukázková data pro ${PROVIDERS[provider]} byla načtena.`); saveState();
+        }
+    });
+    elements.fxRate?.addEventListener('input', scheduleRecalc);
+    elements.outCurrency?.addEventListener('change', scheduleRecalc);
+    elements.annuityInput?.addEventListener('input', calculateAnnuity);
+    elements.clientNameInput?.addEventListener('input', (e) => {
+        state.clientName = e.target.value;
+        saveState();
+    });
+    elements.clientNameInput?.addEventListener('blur', (e) => {
+        const trimmed = e.target.value.trim();
+        if (trimmed !== e.target.value) {
+            e.target.value = trimmed;
+        }
+        state.clientName = trimmed;
+        saveState();
+    });
+    elements.clientSalutationInput?.addEventListener('input', (e) => {
+        state.clientSalutation = e.target.value;
+        saveState();
+    });
+    elements.clientSalutationInput?.addEventListener('blur', (e) => {
+        const trimmed = e.target.value.trim();
+        if (trimmed !== e.target.value) {
+            e.target.value = trimmed;
+        }
+        state.clientSalutation = trimmed;
+        saveState();
+    });
+    elements.clientToneInputs.forEach((input) => {
+        input.addEventListener('change', (e) => {
+            if (!e.target.checked) return;
+            state.clientTone = e.target.value === 'tykani' ? 'tykani' : 'vykani';
+            updateToneInputs();
+            saveState();
+        });
+    });
+    /* PATCH */
+    elements.clientGenderInputs.forEach((input) => {
+        input.addEventListener('change', (e) => {
+            if (!e.target.checked) return;
+            state.clientGender = e.target.value === 'female' ? 'female' : 'male';
+            updateGenderInputs();
+            saveState();
+        });
+    });
+    /* PATCH */
+    elements.clientLanguageInputs.forEach((input) => {
+        input.addEventListener('change', (e) => {
+            if (!e.target.checked) return;
+            state.clientLanguage = e.target.value === 'en' ? 'en' : 'cs';
+            updateLanguageInputs();
+            saveState();
+        });
+    });
+    const providerSections = elements.providerSections;
+    if (providerSections) {
+        providerSections.addEventListener('input', (e) => {
+            if (e.target.matches('input, select')) handleInputChange(e);
+        });
+        providerSections.addEventListener('focusout', (e) => {
+            if (e.target.isContentEditable) handleInputChange(e);
+            const key = e.target.dataset.key;
+            if (key === 'invest' || key === 'totalCurrent' || e.target.id === 'annuity-input') {
+                const num = utils.numCZ(e.target.value);
+                if (isFinite(num)) {
+                    e.target.value = fmt0.format(num);
+                } else {
+                    e.target.value = '';
+                }
+            }
+        });
+        providerSections.addEventListener('focusin', (e) => {
+            const key = e.target.dataset.key;
+            if (key === 'invest' || key === 'totalCurrent' || e.target.id === 'annuity-input') {
+                const num = utils.numCZ(e.target.value);
+                if (isFinite(num)) {
+                    e.target.value = num;
+                }
+            }
+        });
+        providerSections.addEventListener('keydown', e => { if (e.key === 'Enter' && e.target.isContentEditable) { e.preventDefault(); e.target.blur(); } });
+    }
+    elements.annuityInput?.addEventListener('focusin', (e) => {
+        const num = utils.numCZ(e.target.value);
+        if (isFinite(num)) {
+            e.target.value = num;
+        }
+    });
+    elements.annuityInput?.addEventListener('focusout', (e) => {
+        const num = utils.numCZ(e.target.value);
+        if (isFinite(num)) {
+            e.target.value = fmt0.format(num);
+        } else {
+            e.target.value = '';
+        }
+    });
+    elements.importFile?.addEventListener('change', (e) => { if (e.target.files.length > 0) { importState(e.target.files[0]); e.target.value = ''; } });
+    elements.pieSlider?.addEventListener('input', updatePieChartFromSlider);
+    const tooltip = elements.chartTooltip || document.getElementById('chart-tooltip');
+    document.addEventListener('mousemove', e => {
+        let newLeft = e.pageX + 15;
+        let newTop = e.pageY + 15;
+        if (tooltip.offsetWidth && newLeft + tooltip.offsetWidth > window.innerWidth) {
+            newLeft = e.pageX - tooltip.offsetWidth - 15;
+        }
+        tooltip.style.left = `${newLeft}px`;
+        tooltip.style.top = `${newTop}px`;
+    });
+    document.addEventListener('mouseover', e => {
+        const segment = e.target.closest('.pie-segment');
+        const dot = e.target.closest('.line-chart-dot, circle[data-tooltip-text]');
+        if (segment) {
+            tooltip.innerHTML = `<div class="font-bold text-primary">${segment.dataset.name}</div><div class="text-body">${segment.dataset.value} (${segment.dataset.percent})</div>`;
+            tooltip.classList.remove('hidden');
+            tooltip.style.opacity = '1';
+        } else if (dot && dot.dataset.tooltipText) {
+            tooltip.innerHTML = dot.dataset.tooltipText.replace(/&quot;/g, '"');
+            tooltip.classList.remove('hidden');
+            tooltip.style.opacity = '1';
+        }
+    });
+    document.addEventListener('mouseout', e => {
+        if (e.target.closest('.pie-segment, .line-chart-dot, circle[data-tooltip-text]')) {
+            tooltip.classList.add('hidden');
+            tooltip.style.opacity = '0';
+        }
+    });
+    loadState();
+  };
+  init();
+});
+</script>
+</body>
+</html>

--- a/index.html
+++ b/index.html
@@ -2149,34 +2149,23 @@ document.addEventListener('DOMContentLoaded', () => {
         const footnote = exportChart.footnote ? `<p class="chart-footnote">${htmlEscape(exportChart.footnote)}</p>` : '';
         const ariaAttr = htmlEscape(exportChart.ariaLabel || 'Vývoj portfolia');
         /* PATCH: embed hover payloads via JSON blocks (avoid attribute encoding issues) */
-        const viewBoxPayload = exportChart.viewBox ? `${exportChart.viewBox.width},${exportChart.viewBox.height}` : '';
         const hasHoverPayload = Array.isArray(exportChart.hoverPoints) && exportChart.hoverPoints.length > 0;
-        /* PATCH: base64 payloads to survive serialization */
-        const encodePayload = (obj) => {
-            try {
-                return btoa(unescape(encodeURIComponent(JSON.stringify(obj || {}))));
-            } catch (_e) {
-                return '';
-            }
-        };
-        const dataId = hasHoverPayload ? `line-data-${Date.now()}-${Math.random().toString(36).slice(2)}` : '';
-        const metaId = hasHoverPayload ? `${dataId}-meta` : '';
-        const dataB64 = hasHoverPayload ? encodePayload(exportChart.hoverPoints || []) : '';
-        const metaB64 = hasHoverPayload ? encodePayload({ locale: currencyFormat.locale || 'cs-CZ', generic: exportChart.hoverTemplate }) : '';
         const safeJson = (payload) => String(payload || '')
             .replace(/</g, '\\u003c')
             .replace(/<\/script>/gi, '<\\/script>');
-        const dataScript = hasHoverPayload
-            ? `<script type="application/json" id="${dataId}">${safeJson(JSON.stringify(exportChart.hoverPoints || []))}${SCRIPT_CLOSE_TAG}`
+        const payloadId = hasHoverPayload ? `line-payload-${Date.now()}-${Math.random().toString(36).slice(2)}` : '';
+        const payloadScript = hasHoverPayload
+            ? `<script type="application/json" id="${payloadId}">${safeJson(JSON.stringify({
+                points: exportChart.hoverPoints || [],
+                meta: { locale: currencyFormat.locale || 'cs-CZ', generic: exportChart.hoverTemplate },
+                viewBox: exportChart.viewBox || null
+            }))}${SCRIPT_CLOSE_TAG}`
             : '';
-        const metaScript = hasHoverPayload
-            ? `<script type="application/json" id="${metaId}">${safeJson(JSON.stringify({ locale: currencyFormat.locale || 'cs-CZ', generic: exportChart.hoverTemplate }))}${SCRIPT_CLOSE_TAG}`
-            : '';
-        const viewBoxAttr = viewBoxPayload ? htmlEscape(viewBoxPayload) : '';
+        const viewBoxAttr = exportChart.viewBox ? htmlEscape(`${exportChart.viewBox.width},${exportChart.viewBox.height}`) : '';
         const canvasAttrs = hasHoverPayload
-            ? `class="line-canvas" role="img" aria-label="${ariaAttr}" data-viewbox="${viewBoxAttr}" data-line-data="${htmlEscape(dataId)}" data-line-meta-id="${htmlEscape(metaId)}" data-line-points-b64="${htmlEscape(dataB64)}" data-line-meta-b64="${htmlEscape(metaB64)}"`
+            ? `class="line-canvas" role="img" aria-label="${ariaAttr}" data-viewbox="${viewBoxAttr}" data-line-payload="${htmlEscape(payloadId)}"`
             : `class="line-canvas" role="img" aria-label="${ariaAttr}"`;
-        return `<div class="line-export">${legend}<div ${canvasAttrs}>${exportChart.svg}</div>${dataScript}${metaScript}${footnote}</div>`;
+        return `<div class="line-export">${legend}<div ${canvasAttrs}>${exportChart.svg}</div>${payloadScript}${footnote}</div>`;
     }
 
     if (!container) return;
@@ -3673,37 +3662,46 @@ document.addEventListener('DOMContentLoaded', () => {
             for(const attempt of attempts){try{return attempt();}catch(_e){}}
             return null;
           };
-          document.querySelectorAll('.line-canvas[data-line-points], .line-canvas[data-line-data], .line-canvas[data-line-points-b64]').forEach(canvas=>{
+          document.querySelectorAll('.line-canvas[data-line-payload], .line-canvas[data-line-points], .line-canvas[data-line-data], .line-canvas[data-line-points-b64]').forEach(canvas=>{
             const encoding=canvas.getAttribute('data-encoding')||'uri';
+            const parseJsonById=(id)=>{
+              if(!id) return null;
+              const el=document.getElementById(id);
+              if(!el) return null;
+              try{return JSON.parse(el.textContent||'');}catch(_e){return null;}
+            };
             let pts=null;
+            let meta=null;
+            let viewBoxOverride=null;
+            const payloadId=canvas.getAttribute('data-line-payload');
+            if(payloadId){
+              const payload=parseJsonById(payloadId);
+              if(payload){
+                pts=payload.points||payload.hoverPoints||null;
+                meta=payload.meta||payload.metaData||null;
+                viewBoxOverride=payload.viewBox||null;
+              }
+            }
             const b64Attr=canvas.getAttribute('data-line-points-b64');
-            if(b64Attr){
+            if(!pts && b64Attr){
               pts=decodePayload(b64Attr,'b64');
             }
             const dataId=canvas.getAttribute('data-line-data');
-            if(dataId){
-              const scriptEl=document.getElementById(dataId);
-              if(scriptEl){
-                try{ pts=JSON.parse(scriptEl.textContent||''); }catch(_e){}
-              }
+            if(!pts && dataId){
+              pts=parseJsonById(dataId);
             }
             if(!pts){
               const raw=canvas.getAttribute('data-line-points');
               pts=decodePayload(raw,encoding);
             }
             if(!Array.isArray(pts)||!pts.length)return;
-            /* PATCH */
-            let meta=null;
             const metaB64=canvas.getAttribute('data-line-meta-b64');
-            if(metaB64){
+            if(!meta && metaB64){
               meta=decodePayload(metaB64,'b64');
             }
             const metaId=canvas.getAttribute('data-line-meta-id');
-            if(metaId){
-              const metaEl=document.getElementById(metaId);
-              if(metaEl){
-                try{ meta=JSON.parse(metaEl.textContent||''); }catch(_e){}
-              }
+            if(!meta && metaId){
+              meta=parseJsonById(metaId);
             }
             if(!meta){
               meta=decodePayload(canvas.getAttribute('data-line-meta'),encoding)||{};
@@ -3716,7 +3714,8 @@ document.addEventListener('DOMContentLoaded', () => {
             const basePoints=pts.filter(p=>p.kind==='line').sort((a,b)=>a.x-b.x);
             const svg=canvas.querySelector('svg');
             if(!svg)return;
-            const vbAttr=(canvas.getAttribute('data-viewbox')||svg.getAttribute('viewBox')||'820 380').split(/[,\s]+/);
+            const vbRaw=viewBoxOverride?(viewBoxOverride.width+','+viewBoxOverride.height):(canvas.getAttribute('data-viewbox')||svg.getAttribute('viewBox')||'820 380');
+            const vbAttr=String(vbRaw).split(/[,\s]+/);
             const vbW=parseFloat(vbAttr[0])||820;
             const vbH=parseFloat(vbAttr[1])||380;
             const ns='http://www.w3.org/2000/svg';

--- a/index.html
+++ b/index.html
@@ -2149,11 +2149,14 @@ document.addEventListener('DOMContentLoaded', () => {
         const footnote = exportChart.footnote ? `<p class="chart-footnote">${htmlEscape(exportChart.footnote)}</p>` : '';
         const ariaAttr = htmlEscape(exportChart.ariaLabel || 'Vývoj portfolia');
         /* PATCH */
-        const pointsPayload = exportChart.hoverPoints ? htmlEscape(JSON.stringify(exportChart.hoverPoints)) : '';
+        /* PATCH: robustly encode hover payloads for export tooltip hydration */
+        const pointsPayload = exportChart.hoverPoints
+            ? encodeURIComponent(JSON.stringify(exportChart.hoverPoints))
+            : '';
         /* PATCH */
         const viewBoxPayload = exportChart.viewBox ? `${exportChart.viewBox.width},${exportChart.viewBox.height}` : '';
         /* PATCH */
-        const metaPayload = htmlEscape(JSON.stringify({
+        const metaPayload = encodeURIComponent(JSON.stringify({
             locale: currencyFormat.locale || 'cs-CZ',
             generic: exportChart.hoverTemplate || '__DATE__\n__VALUE__'
         }));
@@ -3623,12 +3626,12 @@ document.addEventListener('DOMContentLoaded', () => {
         const attachLineCharts=()=>{
           document.querySelectorAll('.line-canvas[data-line-points]').forEach(canvas=>{
             const raw=canvas.getAttribute('data-line-points');
-            let pts;try{pts=JSON.parse(raw);}catch(_e){return;}
+            let pts;try{pts=JSON.parse(decodeURIComponent(raw));}catch(_e){return;}
             if(!pts||!pts.length)return;
             /* PATCH */
             let meta={};
             const metaRaw=canvas.getAttribute('data-line-meta');
-            try{meta=JSON.parse(metaRaw);}catch(_e){}
+            try{meta=JSON.parse(decodeURIComponent(metaRaw));}catch(_e){}
             const locale=meta.locale||'cs-CZ';
             const genericTemplate=meta.generic||'__DATE__\n__VALUE__';
             const fmtInt=new Intl.NumberFormat(locale,{maximumFractionDigits:0});

--- a/index.html
+++ b/index.html
@@ -475,6 +475,8 @@
     .line-chart-dot { cursor: pointer; transition: r 0.2s; outline: none; }
     .line-chart-dot:hover { r: 7; }
     .line-chart-dot:focus-visible { r: 7; outline: 2px solid var(--color-accent); outline-offset: 2px; }
+    /* PATCH: exported line hover dots for static tooltips */
+    .line-hover-dot { cursor: pointer; }
 
     .text-positive { color: var(--color-accent); }
     .text-negative { color: #B2403D; }
@@ -2979,6 +2981,12 @@ document.addEventListener('DOMContentLoaded', () => {
       const ariaLabel = hasIrr
           ? (copy.aria?.withIrr ? copy.aria.withIrr(startLabel, endLabel, formattedTodayValue, formatXirr1(irr, percentFormat)) : `Vývoj portfolia v období ${startLabel} – ${endLabel}; dnešní hodnota ${formattedTodayValue}; XIRR ${formatXirr1(irr, percentFormat)}`)
           : (copy.aria?.withoutIrr ? copy.aria.withoutIrr(startLabel, endLabel, formattedTodayValue) : `Vývoj portfolia v období ${startLabel} – ${endLabel}; dnešní hodnota ${formattedTodayValue}; XIRR není k dispozici.`);
+      /* PATCH: inject explicit hover dots so tooltips work without JS decoding issues */
+      const hoverDots = hoverPoints.map(pt => {
+          const label = htmlEscape(pt.tooltip || '');
+          return `<circle class="line-hover-dot" cx="${pt.x}" cy="${pt.y}" r="8" fill="transparent" data-tooltip-text="${label}" aria-label="${label}" />`;
+      }).join('');
+
       const svg = `
         <svg viewBox="0 0 ${width} ${height}" aria-label="${htmlEscape(ariaLabel)}" role="img">
           ${defs}
@@ -2999,6 +3007,7 @@ document.addEventListener('DOMContentLoaded', () => {
           ${depositMarkers}
           ${todayMarker}
             ${projectionMarkers}
+          ${hoverDots}
         </svg>
       `;
 

--- a/index.html
+++ b/index.html
@@ -2112,6 +2112,13 @@ document.addEventListener('DOMContentLoaded', () => {
         /* PATCH */ frozenTotal: frozenTotalOption = null
     } = options;
 
+    /* PATCH */
+    const currencyFormat = format.currency || {};
+    /* PATCH */
+    const percentFormat = format.percent || {};
+    /* PATCH */
+    const monthsFormat = format.months || {};
+
     if (isStaticExport) {
         const exportChart = buildLineChartForExport(
             funds,

--- a/index.html
+++ b/index.html
@@ -2157,10 +2157,10 @@ document.addEventListener('DOMContentLoaded', () => {
             .replace(/</g, '\\u003c')
             .replace(/<\/script>/gi, '<\\/script>');
         const dataScript = hasHoverPayload
-            ? `<script type="application/json" id="${dataId}">${safeJson(JSON.stringify(exportChart.hoverPoints || []))}</script>`
+            ? `<script type="application/json" id="${dataId}">${safeJson(JSON.stringify(exportChart.hoverPoints || []))}${SCRIPT_CLOSE_TAG}`
             : '';
         const metaScript = hasHoverPayload
-            ? `<script type="application/json" id="${metaId}">${safeJson(JSON.stringify({ locale: currencyFormat.locale || 'cs-CZ', generic: exportChart.hoverTemplate }))}</script>`
+            ? `<script type="application/json" id="${metaId}">${safeJson(JSON.stringify({ locale: currencyFormat.locale || 'cs-CZ', generic: exportChart.hoverTemplate }))}${SCRIPT_CLOSE_TAG}`
             : '';
         const viewBoxAttr = viewBoxPayload ? htmlEscape(viewBoxPayload) : '';
         const canvasAttrs = hasHoverPayload

--- a/index.html
+++ b/index.html
@@ -2170,9 +2170,13 @@ document.addEventListener('DOMContentLoaded', () => {
                 generic: exportChart.hoverTemplate
             })
             : '';
+        /* PATCH: escape payloads to keep attributes valid */
+        const pointsAttr = pointsPayload ? htmlEscape(pointsPayload) : '';
+        const viewBoxAttr = viewBoxPayload ? htmlEscape(viewBoxPayload) : '';
+        const metaAttr = metaPayload ? htmlEscape(metaPayload) : '';
         /* PATCH */
         const canvasAttrs = pointsPayload
-            ? `class="line-canvas" role="img" aria-label="${ariaAttr}" data-encoding="b64" data-line-points="${pointsPayload}" data-viewbox="${viewBoxPayload}" ${metaPayload ? `data-line-meta="${metaPayload}"` : ''}`
+            ? `class="line-canvas" role="img" aria-label="${ariaAttr}" data-encoding="b64" data-line-points="${pointsAttr}" data-viewbox="${viewBoxAttr}" ${metaAttr ? `data-line-meta="${metaAttr}"` : ''}`
             : `class="line-canvas" role="img" aria-label="${ariaAttr}"`;
         return `<div class="line-export">${legend}<div ${canvasAttrs}>${exportChart.svg}</div>${footnote}</div>`;
     }
@@ -3635,13 +3639,16 @@ document.addEventListener('DOMContentLoaded', () => {
         document.addEventListener('mouseout',e=>{if(!e.target.closest('[data-tooltip-text]'))return;hide();});
         const attachLineCharts=()=>{
           const decodePayload=(raw, encoding)=>{
+            /* PATCH: normalise payloads before decoding */
             if(!raw)return null;
+            const cleaned=String(raw).replace(/\s+/g,'').replace(/&amp;/g,'&');
             const attempts=[];
             if(encoding==='b64'){
-              attempts.push(() => JSON.parse(decodeURIComponent(atob(raw))));
+              attempts.push(() => JSON.parse(decodeURIComponent(atob(cleaned))));
+              attempts.push(() => JSON.parse(atob(cleaned)));
             }
-            attempts.push(() => JSON.parse(raw));
-            attempts.push(() => JSON.parse(decodeURIComponent(raw)));
+            attempts.push(() => JSON.parse(cleaned));
+            attempts.push(() => JSON.parse(decodeURIComponent(cleaned)));
             for(const attempt of attempts){try{return attempt();}catch(_e){}}
             return null;
           };

--- a/index.html
+++ b/index.html
@@ -2146,8 +2146,13 @@ document.addEventListener('DOMContentLoaded', () => {
         /* PATCH */
         const viewBoxPayload = exportChart.viewBox ? `${exportChart.viewBox.width},${exportChart.viewBox.height}` : '';
         /* PATCH */
+        const metaPayload = htmlEscape(JSON.stringify({
+            locale: currencyFormat.locale || 'cs-CZ',
+            generic: exportChart.hoverTemplate || '__DATE__\n__VALUE__'
+        }));
+        /* PATCH */
         const canvasAttrs = pointsPayload
-            ? `class="line-canvas" role="img" aria-label="${ariaAttr}" data-line-points="${pointsPayload}" data-viewbox="${viewBoxPayload}"`
+            ? `class="line-canvas" role="img" aria-label="${ariaAttr}" data-line-points="${pointsPayload}" data-viewbox="${viewBoxPayload}" data-line-meta="${metaPayload}"`
             : `class="line-canvas" role="img" aria-label="${ariaAttr}"`;
         return `<div class="line-export">${legend}<div ${canvasAttrs}>${exportChart.svg}</div>${footnote}</div>`;
     }
@@ -2903,6 +2908,7 @@ document.addEventListener('DOMContentLoaded', () => {
       /* PATCH */
       const hoverBase = hasIrr ? [...valuePoints, ...projectionPoints] : contributionPoints;
       /* PATCH */
+      /* PATCH */
       const hoverPointsBase = hoverBase.map(point => {
           const dateLabel = formatDateLocal(point.date);
           const valueLabel = formatCurrency0(point.value, outCurr, currencyFormat);
@@ -2912,7 +2918,10 @@ document.addEventListener('DOMContentLoaded', () => {
           return {
               x: formatCoord(xScale(point.date)),
               y: formatCoord(yScale(point.value)),
-              tooltip
+              tooltip,
+              /* PATCH */ kind: 'line',
+              /* PATCH */ t: point.date.getTime(),
+              /* PATCH */ v: point.value
           };
       });
 
@@ -2923,7 +2932,10 @@ document.addEventListener('DOMContentLoaded', () => {
           return {
               x: formatCoord(xScale(point.date)),
               y: formatCoord(yScale(yCoord)),
-              tooltip
+              tooltip,
+              /* PATCH */ kind: 'marker',
+              /* PATCH */ t: point.date.getTime(),
+              /* PATCH */ v: yCoord
           };
       });
 
@@ -2943,6 +2955,17 @@ document.addEventListener('DOMContentLoaded', () => {
           : `Dnes (${formatDateLocal(today)}): ${formattedTodayValue}`;
       /* PATCH: remove native title tooltip, keep aria label for accessibility */
       const todayMarker = hasIrr ? `<circle cx="${formatCoord(xScale(today))}" cy="${formatCoord(yScale(valueAtToday))}" r="6" fill="#4DB1C8" stroke="#ffffff" stroke-width="2" aria-label="${htmlEscape(todayTooltip)}" data-tooltip-text="${htmlEscape(todayTooltip)}"></circle>` : '';
+      /* PATCH */
+      if (hasIrr) {
+          hoverPoints.push({
+              x: formatCoord(xScale(today)),
+              y: formatCoord(yScale(valueAtToday)),
+              tooltip: todayTooltip,
+              kind: 'marker',
+              t: today.getTime(),
+              v: valueAtToday
+          });
+      }
 
       const startLabel = formatDateLocal(firstDate);
       const endLabel = formatDateLocal(timelineEnd);
@@ -2990,6 +3013,8 @@ document.addEventListener('DOMContentLoaded', () => {
           ariaLabel,
           /* PATCH */
           hoverPoints,
+          /* PATCH */
+          hoverTemplate: tooltipCopy.generic ? tooltipCopy.generic('__DATE__', '__VALUE__') : '__DATE__\n__VALUE__',
           /* PATCH */
           viewBox: { width, height }
       };
@@ -3561,9 +3586,121 @@ document.addEventListener('DOMContentLoaded', () => {
       const reportDateScript = "(function(){var el=document.getElementById('report-date');if(!el)return;var locale=el.getAttribute('data-locale')||'cs-CZ';var src=el.getAttribute('data-ts');var d=src?new Date(Number(src)||src):new Date();if(isNaN(d))d=new Date();el.textContent=d.toLocaleDateString(locale);})();";
       /* PATCH */
       const footerYearScript = "(function(){var y=document.getElementById('year');if(y)y.textContent=new Date().getFullYear();})();";
-      const tooltipScript = `document.addEventListener('DOMContentLoaded',()=>{const tooltip=document.createElement('div');tooltip.style.position='fixed';tooltip.style.pointerEvents='none';tooltip.style.padding='0.4rem 0.6rem';tooltip.style.background='rgba(15,23,42,0.92)';tooltip.style.color='#f8fafc';tooltip.style.fontSize='0.75rem';tooltip.style.borderRadius='0.5rem';tooltip.style.opacity='0';tooltip.style.transition='opacity 0.15s ease';tooltip.style.zIndex='50';document.body.appendChild(tooltip);let active=false;const move=e=>{if(!active)return;tooltip.style.left=e.clientX+12+'px';tooltip.style.top=e.clientY+12+'px';};const hide=()=>{active=false;tooltip.style.opacity='0';};document.addEventListener('mousemove',move);document.addEventListener('mouseover',e=>{const target=e.target.closest('[data-tooltip-text]');if(!target)return;tooltip.textContent=target.getAttribute('data-tooltip-text')||'';tooltip.style.left=e.clientX+12+'px';tooltip.style.top=e.clientY+12+'px';tooltip.style.opacity='1';active=true;});document.addEventListener('mouseout',e=>{if(!e.target.closest('[data-tooltip-text]'))return;hide();});const attachLineCharts=()=>{document.querySelectorAll('.line-canvas[data-line-points]').forEach(canvas=>{const raw=canvas.getAttribute('data-line-points');let pts;try{pts=JSON.parse(raw);}catch(_e){return;}if(!pts||!pts.length)return;const svg=canvas.querySelector('svg');if(!svg)return;const vbAttr=(canvas.getAttribute('data-viewbox')||svg.getAttribute('viewBox')||'820 380').split(/[,\s]+/);const vbW=parseFloat(vbAttr[0])||820;const vbH=parseFloat(vbAttr[1])||380;const ns='http://www.w3.org/2000/svg';const guide=document.createElementNS(ns,'g');guide.setAttribute('class','line-hover');guide.style.display='none';const gl=document.createElementNS(ns,'line');gl.setAttribute('stroke','#94a3b8');gl.setAttribute('stroke-width','1');gl.setAttribute('stroke-dasharray','4 3');const gc=document.createElementNS(ns,'circle');gc.setAttribute('r','5');gc.setAttribute('fill','#0d2c54');gc.setAttribute('stroke','#ffffff');gc.setAttribute('stroke-width','2');guide.appendChild(gl);guide.appendChild(gc);svg.appendChild(guide);const hideGuide=()=>{guide.style.display='none';hide();};const showPoint=(pt)=>{guide.style.display='block';gl.setAttribute('x1',pt.x);gl.setAttribute('x2',pt.x);gl.setAttribute('y1',pt.y);gl.setAttribute('y2',vbH-32);gc.setAttribute('cx',pt.x);gc.setAttribute('cy',pt.y);tooltip.textContent=pt.tooltip||'';tooltip.style.opacity='1';active=true;};canvas.addEventListener('mousemove',ev=>{const rect=svg.getBoundingClientRect();const scaleX=vbW/rect.width;const scaleY=vbH/rect.height;const x=(ev.clientX-rect.left)*scaleX;let best=pts[0];let dist=Math.abs(best.x-x);for(let i=1;i<pts.length;i++){const dx=Math.abs(pts[i].x-x);const isCloser=dx<dist;const tieBetter=dx===dist&&pts[i].y<best.y; /* PATCH: prefer higher-value point on ties */ if(isCloser||tieBetter){dist=dx;best=pts[i];}}tooltip.style.left=ev.clientX+12+'px';tooltip.style.top=ev.clientY+12+'px';showPoint(best);});canvas.addEventListener('mouseleave',hideGuide);canvas.addEventListener('blur',hideGuide,{capture:true});});};attachLineCharts();});`;
-      /* PATCH */
-      const scriptBundle = `${reportDateScript}${footerYearScript}${tooltipScript}`;
+            const tooltipScript = `document.addEventListener('DOMContentLoaded',()=>{
+        const tooltip=document.createElement('div');
+        tooltip.style.position='fixed';
+        tooltip.style.pointerEvents='none';
+        tooltip.style.padding='0.4rem 0.6rem';
+        tooltip.style.background='rgba(15,23,42,0.92)';
+        tooltip.style.color='#f8fafc';
+        tooltip.style.fontSize='0.75rem';
+        tooltip.style.borderRadius='0.5rem';
+        tooltip.style.opacity='0';
+        tooltip.style.transition='opacity 0.15s ease';
+        tooltip.style.zIndex='50';
+        document.body.appendChild(tooltip);
+        let active=false;
+        const move=e=>{if(!active)return;tooltip.style.left=e.clientX+12+'px';tooltip.style.top=e.clientY+12+'px';};
+        const hide=()=>{active=false;tooltip.style.opacity='0';};
+        document.addEventListener('mousemove',move);
+        document.addEventListener('mouseover',e=>{
+          const target=e.target.closest('[data-tooltip-text]');
+          if(!target)return;
+          tooltip.textContent=target.getAttribute('data-tooltip-text')||'';
+          tooltip.style.left=e.clientX+12+'px';
+          tooltip.style.top=e.clientY+12+'px';
+          tooltip.style.opacity='1';
+          active=true;
+        });
+        document.addEventListener('mouseout',e=>{if(!e.target.closest('[data-tooltip-text]'))return;hide();});
+        const attachLineCharts=()=>{
+          document.querySelectorAll('.line-canvas[data-line-points]').forEach(canvas=>{
+            const raw=canvas.getAttribute('data-line-points');
+            let pts;try{pts=JSON.parse(raw);}catch(_e){return;}
+            if(!pts||!pts.length)return;
+            /* PATCH */
+            let meta={};
+            const metaRaw=canvas.getAttribute('data-line-meta');
+            try{meta=JSON.parse(metaRaw);}catch(_e){}
+            const locale=meta.locale||'cs-CZ';
+            const genericTemplate=meta.generic||'__DATE__\n__VALUE__';
+            const fmtInt=new Intl.NumberFormat(locale,{maximumFractionDigits:0});
+            const formatValue=(v)=>fmtInt.format(Math.round(v));
+            const formatDate=(ms)=>{const d=new Date(ms);return d.toLocaleDateString(locale);};
+            const basePoints=pts.filter(p=>p.kind==='line').sort((a,b)=>a.x-b.x);
+            const svg=canvas.querySelector('svg');
+            if(!svg)return;
+            const vbAttr=(canvas.getAttribute('data-viewbox')||svg.getAttribute('viewBox')||'820 380').split(/[,\s]+/);
+            const vbW=parseFloat(vbAttr[0])||820;
+            const vbH=parseFloat(vbAttr[1])||380;
+            const ns='http://www.w3.org/2000/svg';
+            const guide=document.createElementNS(ns,'g');
+            guide.setAttribute('class','line-hover');
+            guide.style.display='none';
+            const gl=document.createElementNS(ns,'line');
+            gl.setAttribute('stroke','#94a3b8');
+            gl.setAttribute('stroke-width','1');
+            gl.setAttribute('stroke-dasharray','4 3');
+            const gc=document.createElementNS(ns,'circle');
+            gc.setAttribute('r','5');
+            gc.setAttribute('fill','#0d2c54');
+            gc.setAttribute('stroke','#ffffff');
+            gc.setAttribute('stroke-width','2');
+            guide.appendChild(gl);guide.appendChild(gc);
+            svg.appendChild(guide);
+            const hideGuide=()=>{guide.style.display='none';hide();};
+            const showPoint=(pt,textOverride)=>{
+              guide.style.display='block';
+              gl.setAttribute('x1',pt.x);gl.setAttribute('x2',pt.x);
+              gl.setAttribute('y1',pt.y);gl.setAttribute('y2',vbH-32);
+              gc.setAttribute('cx',pt.x);gc.setAttribute('cy',pt.y);
+              tooltip.textContent=textOverride||pt.tooltip||'';
+              tooltip.style.opacity='1';
+              active=true;
+            };
+            canvas.addEventListener('mousemove',ev=>{
+              const rect=svg.getBoundingClientRect();
+              const scaleX=vbW/rect.width;
+              const x=(ev.clientX-rect.left)*scaleX;
+              let best=pts[0];
+              let dist=Math.abs(best.x-x);
+              for(let i=1;i<pts.length;i++){
+                const dx=Math.abs(pts[i].x-x);
+                const isCloser=dx<dist;
+                const tieBetter=dx===dist&&pts[i].y<best.y; /* PATCH: prefer higher-value point on ties */
+                if(isCloser||tieBetter){dist=dx;best=pts[i];}
+              }
+              tooltip.style.left=ev.clientX+12+'px';
+              tooltip.style.top=ev.clientY+12+'px';
+              const snapThreshold=12;
+              if(best.kind!=='line'&&dist<=snapThreshold){showPoint(best);return;}
+              if(basePoints.length>=2){
+                let prev=basePoints[0];
+                let next=basePoints[basePoints.length-1];
+                for(let i=0;i<basePoints.length;i++){
+                  if(basePoints[i].x<=x){prev=basePoints[i];}
+                  if(basePoints[i].x>=x){next=basePoints[i];break;}
+                }
+                if(!next||!prev){showPoint(best);return;}
+                if(Math.abs(next.x-prev.x)<1e-4){showPoint(next);return;}
+                const ratio=Math.min(1,Math.max(0,(x-prev.x)/(next.x-prev.x)));
+                const interpX=prev.x+ratio*(next.x-prev.x);
+                const interpY=prev.y+ratio*(next.y-prev.y);
+                const interpValue=prev.v+ratio*(next.v-prev.v);
+                const interpDate=prev.t+ratio*(next.t-prev.t);
+                const text=genericTemplate.replace(/__DATE__/g,formatDate(interpDate)).replace(/__VALUE__/g,formatValue(interpValue));
+                showPoint({x:interpX,y:interpY,tooltip:text},text);
+                return;
+              }
+              showPoint(best);
+            });
+            canvas.addEventListener('mouseleave',hideGuide);
+            canvas.addEventListener('blur',hideGuide,{capture:true});
+          });
+        };
+        attachLineCharts();
+      });`;
+const scriptBundle = `${reportDateScript}${footerYearScript}${tooltipScript}`;
 
       const html = `<!doctype html>
 <html lang="${copy.htmlLang}">

--- a/index.html
+++ b/index.html
@@ -2170,15 +2170,20 @@ document.addEventListener('DOMContentLoaded', () => {
                 generic: exportChart.hoverTemplate
             })
             : '';
-        /* PATCH: escape payloads to keep attributes valid */
-        const pointsAttr = pointsPayload ? htmlEscape(pointsPayload) : '';
+        /* PATCH: introduce JSON data blocks to avoid attribute corruption */
+        const dataId = pointsPayload ? `line-data-${Date.now()}-${Math.random().toString(36).slice(2)}` : '';
+        const metaId = metaPayload ? `${dataId || 'line-meta'}-meta` : '';
+        const safeJson = (payload) => String(payload || '')
+            .replace(/</g, '\\u003c')
+            .replace(/<\/script>/gi, '<\\/script>');
+        const dataScript = pointsPayload ? `<script type="application/json" id="${dataId}">${safeJson(exportChart.hoverPoints ? JSON.stringify(exportChart.hoverPoints) : '')}</script>` : '';
+        const metaScript = metaPayload ? `<script type="application/json" id="${metaId}">${safeJson(exportChart.hoverTemplate ? JSON.stringify({ locale: currencyFormat.locale || 'cs-CZ', generic: exportChart.hoverTemplate }) : '')}</script>` : '';
         const viewBoxAttr = viewBoxPayload ? htmlEscape(viewBoxPayload) : '';
-        const metaAttr = metaPayload ? htmlEscape(metaPayload) : '';
         /* PATCH */
         const canvasAttrs = pointsPayload
-            ? `class="line-canvas" role="img" aria-label="${ariaAttr}" data-encoding="b64" data-line-points="${pointsAttr}" data-viewbox="${viewBoxAttr}" ${metaAttr ? `data-line-meta="${metaAttr}"` : ''}`
+            ? `class="line-canvas" role="img" aria-label="${ariaAttr}" data-viewbox="${viewBoxAttr}" data-line-data="${htmlEscape(dataId)}" ${metaId ? `data-line-meta-id="${htmlEscape(metaId)}"` : ''}`
             : `class="line-canvas" role="img" aria-label="${ariaAttr}"`;
-        return `<div class="line-export">${legend}<div ${canvasAttrs}>${exportChart.svg}</div>${footnote}</div>`;
+        return `<div class="line-export">${legend}<div ${canvasAttrs}>${exportChart.svg}</div>${dataScript}${metaScript}${footnote}</div>`;
     }
 
     if (!container) return;
@@ -3652,13 +3657,33 @@ document.addEventListener('DOMContentLoaded', () => {
             for(const attempt of attempts){try{return attempt();}catch(_e){}}
             return null;
           };
-          document.querySelectorAll('.line-canvas[data-line-points]').forEach(canvas=>{
+          document.querySelectorAll('.line-canvas[data-line-points], .line-canvas[data-line-data]').forEach(canvas=>{
             const encoding=canvas.getAttribute('data-encoding')||'uri';
-            const raw=canvas.getAttribute('data-line-points');
-            const pts=decodePayload(raw,encoding);
+            let pts=null;
+            const dataId=canvas.getAttribute('data-line-data');
+            if(dataId){
+              const scriptEl=document.getElementById(dataId);
+              if(scriptEl){
+                try{ pts=JSON.parse(scriptEl.textContent||''); }catch(_e){}
+              }
+            }
+            if(!pts){
+              const raw=canvas.getAttribute('data-line-points');
+              pts=decodePayload(raw,encoding);
+            }
             if(!Array.isArray(pts)||!pts.length)return;
             /* PATCH */
-            const meta=decodePayload(canvas.getAttribute('data-line-meta'),encoding)||{};
+            let meta=null;
+            const metaId=canvas.getAttribute('data-line-meta-id');
+            if(metaId){
+              const metaEl=document.getElementById(metaId);
+              if(metaEl){
+                try{ meta=JSON.parse(metaEl.textContent||''); }catch(_e){}
+              }
+            }
+            if(!meta){
+              meta=decodePayload(canvas.getAttribute('data-line-meta'),encoding)||{};
+            }
             const locale=meta.locale||'cs-CZ';
             const genericTemplate=meta.generic||'__DATE__\n__VALUE__';
             const fmtInt=new Intl.NumberFormat(locale,{maximumFractionDigits:0});

--- a/index.html
+++ b/index.html
@@ -3367,6 +3367,11 @@ document.addEventListener('DOMContentLoaded', () => {
   };
 
   const exportToStaticHTML = () => {
+      /* PATCH: guard export pipeline so errors surface and download still proceeds when possible */
+      const failExport = (err) => {
+          console.error('Export failed:', err);
+          showToast('Export se nepodařil, zkontrolujte konzoli.', 'error');
+      };
       const clientName = (state.clientName || '').trim();
       if (!clientName) {
           showToast('Před exportem vyplňte jméno klienta.', 'error');
@@ -3399,7 +3404,13 @@ document.addEventListener('DOMContentLoaded', () => {
           document.activeElement.blur();
       }
 
-      const snapshot = processAllRows();
+      let snapshot;
+      try {
+          snapshot = processAllRows();
+      } catch (err) {
+          failExport(err);
+          return;
+      }
       const outCurr = elements.outCurrency?.value || 'CZK';
       const fxRate = utils.numCZ(elements.fxRate?.value);
       const hasValidFx = Number.isFinite(fxRate) && fxRate > 0;
@@ -3411,7 +3422,13 @@ document.addEventListener('DOMContentLoaded', () => {
       }
 
       /* PATCH */
-      const copy = buildExportCopy({ language: clientLanguage, tone: communicationTone, gender: clientGender });
+      let copy;
+      try {
+          copy = buildExportCopy({ language: clientLanguage, tone: communicationTone, gender: clientGender });
+      } catch (err) {
+          failExport(err);
+          return;
+      }
       /* PATCH */
       const heroLeadText = copy.hero.lead(salutation);
 
@@ -3455,15 +3472,21 @@ document.addEventListener('DOMContentLoaded', () => {
           : `<div class="rounded-2xl border border-subtle bg-card-muted py-6 text-center text-muted">${htmlEscape(copy.pie.noData)}</div>`;
 
       const frozenForExport = (snapshot.portfolioSummary.totalCurrentConverted || 0) - (snapshot.portfolioSummary.totalCurrentActive || 0);
-      const lineBlock = renderLineChart(null, snapshot.funds || [], snapshot.portfolioSummary.portfolioIrr, outCurr, fxRate, {
-        isStaticExport: true,
-        conversionReady,
-        /* PATCH */ copy: copy.line,
-        /* PATCH */ format: copy.format,
-        /* PATCH */ language: copy.language,
-        /* PATCH */ activeFunds: snapshot.activeFunds || [],
-        /* PATCH */ frozenTotal: frozenForExport
-      });
+      let lineBlock;
+      try {
+          lineBlock = renderLineChart(null, snapshot.funds || [], snapshot.portfolioSummary.portfolioIrr, outCurr, fxRate, {
+            isStaticExport: true,
+            conversionReady,
+            /* PATCH */ copy: copy.line,
+            /* PATCH */ format: copy.format,
+            /* PATCH */ language: copy.language,
+            /* PATCH */ activeFunds: snapshot.activeFunds || [],
+            /* PATCH */ frozenTotal: frozenForExport
+          });
+      } catch (err) {
+          console.error('Export line chart failed:', err);
+          lineBlock = `<div class="rounded-2xl border border-subtle bg-card-muted py-10 text-center text-muted">${htmlEscape(copy.line.empty || 'Pro liniový graf nejsou k dispozici údaje.')}</div>`;
+      }
 
       const explanationsBlock = `<div class="export-explanations">
         <article>
@@ -3772,17 +3795,21 @@ const scriptBundle = `${reportDateScript}${footerYearScript}${tooltipScript}`;
 </body>
 </html>`;
 
-      const blob = new Blob([html], { type: 'text/html' });
-      const url = URL.createObjectURL(blob);
-      const anchor = document.createElement('a');
-      const safeName = clientName.toLowerCase().replace(/[^\p{L}\p{N}\s-]+/gu, '').trim().replace(/\s+/g, '-');
-      anchor.href = url;
-      anchor.download = `report-${safeName || 'klient'}-${generatedAt.toISOString().split('T')[0]}.html`;
-      document.body.appendChild(anchor);
-      anchor.click();
-      document.body.removeChild(anchor);
-      URL.revokeObjectURL(url);
-      showToast('Report byl exportován.');
+      try {
+          const blob = new Blob([html], { type: 'text/html' });
+          const url = URL.createObjectURL(blob);
+          const anchor = document.createElement('a');
+          const safeName = clientName.toLowerCase().replace(/[^\p{L}\p{N}\s-]+/gu, '').trim().replace(/\s+/g, '-');
+          anchor.href = url;
+          anchor.download = `report-${safeName || 'klient'}-${generatedAt.toISOString().split('T')[0]}.html`;
+          document.body.appendChild(anchor);
+          anchor.click();
+          document.body.removeChild(anchor);
+          URL.revokeObjectURL(url);
+          showToast('Report byl exportován.');
+      } catch (err) {
+          failExport(err);
+      }
   };
 
   const calculateAnnuity = () => {

--- a/index.html
+++ b/index.html
@@ -2291,7 +2291,41 @@ document.addEventListener('DOMContentLoaded', () => {
     const xToday = xScale(today);
     /* PATCH */
     const formattedTodayValue = formattedTodayValueOverride ?? formatCurrency0(valueAtToday, outCurr);
-    const snapPoints = [{x: xToday, y: yScale(valueAtToday), date: today, value: valueAtToday, isToday: true}];
+    const snapPoints = [];
+    const seenSnaps = new Set();
+    const pushSnap = (pt) => {
+        const key = `${Math.round(pt.x*100)/100}|${Math.round(pt.y*100)/100}`;
+        if (seenSnaps.has(key)) return;
+        seenSnaps.add(key);
+        snapPoints.push(pt);
+    };
+    /* PATCH: add today point first */
+    pushSnap({x: xToday, y: yScale(valueAtToday), date: today, value: valueAtToday, isToday: true});
+
+    /* PATCH: add base hover points along the value curve */
+    historicalPoints.forEach(p => {
+        const x = xScale(p.date);
+        const y = yScale(p.value);
+        pushSnap({
+            x,
+            y,
+            date: p.date,
+            value: p.value,
+            tooltipText: `<div class="font-bold text-primary">${p.date.toLocaleDateString('cs-CZ')}</div><div class="text-body">${formatCurrency0(p.value, outCurr)}</div>`
+        });
+    });
+    projectionPoints.forEach(p => {
+        const x = xScale(p.date);
+        const y = yScale(p.value);
+        pushSnap({
+            x,
+            y,
+            date: p.date,
+            value: p.value,
+            tooltipText: `<div class="font-bold text-primary">${p.date.toLocaleDateString('cs-CZ')}</div><div class="text-body">${formatCurrency0(p.value, outCurr)}</div>`
+        });
+    });
+
     if (!options.isForPdf) {
         const dayEntries = Array.from(depositsByDay.values()).sort((a, b) => a.date - b.date);
         dayEntries.forEach(entry => {
@@ -2311,7 +2345,7 @@ document.addEventListener('DOMContentLoaded', () => {
                 ? `Vklady ${dateLabel}: ${entry.entries.map(d => `${d.fund} ${formatCurrency0(d.amount, outCurr)}`).join(', ')}`
                 : `Vklad ${dateLabel}: ${entry.entries[0].fund} ${formatCurrency0(entry.entries[0].amount, outCurr)}`;
             innerHTML += `<circle class='line-chart-dot' cx="${x}" cy="${y}" r="4" fill="#4DB1C8" tabindex="0" aria-label="${htmlEscape(ariaLabel)}" data-tooltip-text='${escapedTooltipText}'></circle>`;
-            snapPoints.push({
+            pushSnap({
                 x,
                 y,
                 date: entry.date,
@@ -2869,7 +2903,7 @@ document.addEventListener('DOMContentLoaded', () => {
       /* PATCH */
       const hoverBase = hasIrr ? [...valuePoints, ...projectionPoints] : contributionPoints;
       /* PATCH */
-      const hoverPoints = hoverBase.map(point => {
+      const hoverPointsBase = hoverBase.map(point => {
           const dateLabel = formatDateLocal(point.date);
           const valueLabel = formatCurrency0(point.value, outCurr, currencyFormat);
           const tooltip = tooltipCopy.generic
@@ -2880,6 +2914,26 @@ document.addEventListener('DOMContentLoaded', () => {
               y: formatCoord(yScale(point.value)),
               tooltip
           };
+      });
+
+      /* PATCH: add deposit hover points so jumps snap to purchase markers */
+      const depositHoverPoints = depositPoints.map(point => {
+          const tooltip = formatDepositTooltip(point);
+          const yCoord = hasIrr ? point.value : point.contributions;
+          return {
+              x: formatCoord(xScale(point.date)),
+              y: formatCoord(yScale(yCoord)),
+              tooltip
+          };
+      });
+
+      /* PATCH: prefer higher points on identical x for smoother snapping at jumps */
+      const hoverPoints = [...hoverPointsBase, ...depositHoverPoints].sort((a, b) => {
+          const dx = a.x - b.x;
+          if (Math.abs(dx) < 1e-6) {
+              return a.y - b.y; // smaller y = higher value
+          }
+          return dx;
       });
 
       /* PATCH */
@@ -3507,7 +3561,7 @@ document.addEventListener('DOMContentLoaded', () => {
       const reportDateScript = "(function(){var el=document.getElementById('report-date');if(!el)return;var locale=el.getAttribute('data-locale')||'cs-CZ';var src=el.getAttribute('data-ts');var d=src?new Date(Number(src)||src):new Date();if(isNaN(d))d=new Date();el.textContent=d.toLocaleDateString(locale);})();";
       /* PATCH */
       const footerYearScript = "(function(){var y=document.getElementById('year');if(y)y.textContent=new Date().getFullYear();})();";
-      const tooltipScript = `document.addEventListener('DOMContentLoaded',()=>{const tooltip=document.createElement('div');tooltip.style.position='fixed';tooltip.style.pointerEvents='none';tooltip.style.padding='0.4rem 0.6rem';tooltip.style.background='rgba(15,23,42,0.92)';tooltip.style.color='#f8fafc';tooltip.style.fontSize='0.75rem';tooltip.style.borderRadius='0.5rem';tooltip.style.opacity='0';tooltip.style.transition='opacity 0.15s ease';tooltip.style.zIndex='50';document.body.appendChild(tooltip);let active=false;const move=e=>{if(!active)return;tooltip.style.left=e.clientX+12+'px';tooltip.style.top=e.clientY+12+'px';};const hide=()=>{active=false;tooltip.style.opacity='0';};document.addEventListener('mousemove',move);document.addEventListener('mouseover',e=>{const target=e.target.closest('[data-tooltip-text]');if(!target)return;tooltip.textContent=target.getAttribute('data-tooltip-text')||'';tooltip.style.left=e.clientX+12+'px';tooltip.style.top=e.clientY+12+'px';tooltip.style.opacity='1';active=true;});document.addEventListener('mouseout',e=>{if(!e.target.closest('[data-tooltip-text]'))return;hide();});const attachLineCharts=()=>{document.querySelectorAll('.line-canvas[data-line-points]').forEach(canvas=>{const raw=canvas.getAttribute('data-line-points');let pts;try{pts=JSON.parse(raw);}catch(_e){return;}if(!pts||!pts.length)return;const svg=canvas.querySelector('svg');if(!svg)return;const vbAttr=(canvas.getAttribute('data-viewbox')||svg.getAttribute('viewBox')||'820 380').split(/[,\s]+/);const vbW=parseFloat(vbAttr[0])||820;const vbH=parseFloat(vbAttr[1])||380;const ns='http://www.w3.org/2000/svg';const guide=document.createElementNS(ns,'g');guide.setAttribute('class','line-hover');guide.style.display='none';const gl=document.createElementNS(ns,'line');gl.setAttribute('stroke','#94a3b8');gl.setAttribute('stroke-width','1');gl.setAttribute('stroke-dasharray','4 3');const gc=document.createElementNS(ns,'circle');gc.setAttribute('r','5');gc.setAttribute('fill','#0d2c54');gc.setAttribute('stroke','#ffffff');gc.setAttribute('stroke-width','2');guide.appendChild(gl);guide.appendChild(gc);svg.appendChild(guide);const hideGuide=()=>{guide.style.display='none';hide();};const showPoint=(pt)=>{guide.style.display='block';gl.setAttribute('x1',pt.x);gl.setAttribute('x2',pt.x);gl.setAttribute('y1',pt.y);gl.setAttribute('y2',vbH-32);gc.setAttribute('cx',pt.x);gc.setAttribute('cy',pt.y);tooltip.textContent=pt.tooltip||'';tooltip.style.opacity='1';active=true;};canvas.addEventListener('mousemove',ev=>{const rect=svg.getBoundingClientRect();const scaleX=vbW/rect.width;const scaleY=vbH/rect.height;const x=(ev.clientX-rect.left)*scaleX;let best=pts[0];let dist=Math.abs(best.x-x);for(let i=1;i<pts.length;i++){const dx=Math.abs(pts[i].x-x);if(dx<dist){dist=dx;best=pts[i];}}tooltip.style.left=ev.clientX+12+'px';tooltip.style.top=ev.clientY+12+'px';showPoint(best);});canvas.addEventListener('mouseleave',hideGuide);canvas.addEventListener('blur',hideGuide,{capture:true});});};attachLineCharts();});`;
+      const tooltipScript = `document.addEventListener('DOMContentLoaded',()=>{const tooltip=document.createElement('div');tooltip.style.position='fixed';tooltip.style.pointerEvents='none';tooltip.style.padding='0.4rem 0.6rem';tooltip.style.background='rgba(15,23,42,0.92)';tooltip.style.color='#f8fafc';tooltip.style.fontSize='0.75rem';tooltip.style.borderRadius='0.5rem';tooltip.style.opacity='0';tooltip.style.transition='opacity 0.15s ease';tooltip.style.zIndex='50';document.body.appendChild(tooltip);let active=false;const move=e=>{if(!active)return;tooltip.style.left=e.clientX+12+'px';tooltip.style.top=e.clientY+12+'px';};const hide=()=>{active=false;tooltip.style.opacity='0';};document.addEventListener('mousemove',move);document.addEventListener('mouseover',e=>{const target=e.target.closest('[data-tooltip-text]');if(!target)return;tooltip.textContent=target.getAttribute('data-tooltip-text')||'';tooltip.style.left=e.clientX+12+'px';tooltip.style.top=e.clientY+12+'px';tooltip.style.opacity='1';active=true;});document.addEventListener('mouseout',e=>{if(!e.target.closest('[data-tooltip-text]'))return;hide();});const attachLineCharts=()=>{document.querySelectorAll('.line-canvas[data-line-points]').forEach(canvas=>{const raw=canvas.getAttribute('data-line-points');let pts;try{pts=JSON.parse(raw);}catch(_e){return;}if(!pts||!pts.length)return;const svg=canvas.querySelector('svg');if(!svg)return;const vbAttr=(canvas.getAttribute('data-viewbox')||svg.getAttribute('viewBox')||'820 380').split(/[,\s]+/);const vbW=parseFloat(vbAttr[0])||820;const vbH=parseFloat(vbAttr[1])||380;const ns='http://www.w3.org/2000/svg';const guide=document.createElementNS(ns,'g');guide.setAttribute('class','line-hover');guide.style.display='none';const gl=document.createElementNS(ns,'line');gl.setAttribute('stroke','#94a3b8');gl.setAttribute('stroke-width','1');gl.setAttribute('stroke-dasharray','4 3');const gc=document.createElementNS(ns,'circle');gc.setAttribute('r','5');gc.setAttribute('fill','#0d2c54');gc.setAttribute('stroke','#ffffff');gc.setAttribute('stroke-width','2');guide.appendChild(gl);guide.appendChild(gc);svg.appendChild(guide);const hideGuide=()=>{guide.style.display='none';hide();};const showPoint=(pt)=>{guide.style.display='block';gl.setAttribute('x1',pt.x);gl.setAttribute('x2',pt.x);gl.setAttribute('y1',pt.y);gl.setAttribute('y2',vbH-32);gc.setAttribute('cx',pt.x);gc.setAttribute('cy',pt.y);tooltip.textContent=pt.tooltip||'';tooltip.style.opacity='1';active=true;};canvas.addEventListener('mousemove',ev=>{const rect=svg.getBoundingClientRect();const scaleX=vbW/rect.width;const scaleY=vbH/rect.height;const x=(ev.clientX-rect.left)*scaleX;let best=pts[0];let dist=Math.abs(best.x-x);for(let i=1;i<pts.length;i++){const dx=Math.abs(pts[i].x-x);const isCloser=dx<dist;const tieBetter=dx===dist&&pts[i].y<best.y; /* PATCH: prefer higher-value point on ties */ if(isCloser||tieBetter){dist=dx;best=pts[i];}}tooltip.style.left=ev.clientX+12+'px';tooltip.style.top=ev.clientY+12+'px';showPoint(best);});canvas.addEventListener('mouseleave',hideGuide);canvas.addEventListener('blur',hideGuide,{capture:true});});};attachLineCharts();});`;
       /* PATCH */
       const scriptBundle = `${reportDateScript}${footerYearScript}${tooltipScript}`;
 

--- a/index.html
+++ b/index.html
@@ -2149,23 +2149,30 @@ document.addEventListener('DOMContentLoaded', () => {
         const footnote = exportChart.footnote ? `<p class="chart-footnote">${htmlEscape(exportChart.footnote)}</p>` : '';
         const ariaAttr = htmlEscape(exportChart.ariaLabel || 'Vývoj portfolia');
         /* PATCH */
-        /* PATCH: robustly encode hover payloads for export tooltip hydration */
-        /* PATCH: encode hover/meta payloads but keep decoding flexible in the bootstrapper */
+        /* PATCH: robust encoding for hover payloads (base64) */
+        const encodePayload = (obj) => {
+            try {
+                return btoa(unescape(encodeURIComponent(JSON.stringify(obj))));
+            } catch (_e) {
+                return '';
+            }
+        };
+        /* PATCH */
         const pointsPayload = exportChart.hoverPoints
-            ? encodeURIComponent(JSON.stringify(exportChart.hoverPoints))
+            ? encodePayload(exportChart.hoverPoints)
             : '';
         /* PATCH */
         const viewBoxPayload = exportChart.viewBox ? `${exportChart.viewBox.width},${exportChart.viewBox.height}` : '';
         /* PATCH */
         const metaPayload = exportChart.hoverTemplate
-            ? encodeURIComponent(JSON.stringify({
+            ? encodePayload({
                 locale: currencyFormat.locale || 'cs-CZ',
                 generic: exportChart.hoverTemplate
-            }))
+            })
             : '';
         /* PATCH */
         const canvasAttrs = pointsPayload
-            ? `class="line-canvas" role="img" aria-label="${ariaAttr}" data-line-points="${pointsPayload}" data-viewbox="${viewBoxPayload}" ${metaPayload ? `data-line-meta="${metaPayload}"` : ''}`
+            ? `class="line-canvas" role="img" aria-label="${ariaAttr}" data-encoding="b64" data-line-points="${pointsPayload}" data-viewbox="${viewBoxPayload}" ${metaPayload ? `data-line-meta="${metaPayload}"` : ''}`
             : `class="line-canvas" role="img" aria-label="${ariaAttr}"`;
         return `<div class="line-export">${legend}<div ${canvasAttrs}>${exportChart.svg}</div>${footnote}</div>`;
     }
@@ -3627,18 +3634,24 @@ document.addEventListener('DOMContentLoaded', () => {
         });
         document.addEventListener('mouseout',e=>{if(!e.target.closest('[data-tooltip-text]'))return;hide();});
         const attachLineCharts=()=>{
-          const parsePayload=(raw)=>{
+          const decodePayload=(raw, encoding)=>{
             if(!raw)return null;
-            const attempts=[() => JSON.parse(raw),() => JSON.parse(decodeURIComponent(raw))];
+            const attempts=[];
+            if(encoding==='b64'){
+              attempts.push(() => JSON.parse(decodeURIComponent(atob(raw))));
+            }
+            attempts.push(() => JSON.parse(raw));
+            attempts.push(() => JSON.parse(decodeURIComponent(raw)));
             for(const attempt of attempts){try{return attempt();}catch(_e){}}
             return null;
           };
           document.querySelectorAll('.line-canvas[data-line-points]').forEach(canvas=>{
+            const encoding=canvas.getAttribute('data-encoding')||'uri';
             const raw=canvas.getAttribute('data-line-points');
-            const pts=parsePayload(raw);
+            const pts=decodePayload(raw,encoding);
             if(!Array.isArray(pts)||!pts.length)return;
             /* PATCH */
-            const meta=parsePayload(canvas.getAttribute('data-line-meta'))||{};
+            const meta=decodePayload(canvas.getAttribute('data-line-meta'),encoding)||{};
             const locale=meta.locale||'cs-CZ';
             const genericTemplate=meta.generic||'__DATE__\n__VALUE__';
             const fmtInt=new Intl.NumberFormat(locale,{maximumFractionDigits:0});

--- a/index.html
+++ b/index.html
@@ -2148,24 +2148,20 @@ document.addEventListener('DOMContentLoaded', () => {
             : `<div class="line-legend"><span class="legend-pill legend-pill--base" tabindex="0">${baseLegend}</span></div>`;
         const footnote = exportChart.footnote ? `<p class="chart-footnote">${htmlEscape(exportChart.footnote)}</p>` : '';
         const ariaAttr = htmlEscape(exportChart.ariaLabel || 'Vývoj portfolia');
-        /* PATCH: embed hover payloads via JSON blocks (avoid attribute encoding issues) */
+        /* PATCH: embed hover payloads via base64 data attributes for reliable tooltip hydration */
         const hasHoverPayload = Array.isArray(exportChart.hoverPoints) && exportChart.hoverPoints.length > 0;
-        const safeJson = (payload) => String(payload || '')
-            .replace(/</g, '\\u003c')
-            .replace(/<\/script>/gi, '<\\/script>');
-        const payloadId = hasHoverPayload ? `line-payload-${Date.now()}-${Math.random().toString(36).slice(2)}` : '';
-        const payloadScript = hasHoverPayload
-            ? `<script type="application/json" id="${payloadId}">${safeJson(JSON.stringify({
-                points: exportChart.hoverPoints || [],
-                meta: { locale: currencyFormat.locale || 'cs-CZ', generic: exportChart.hoverTemplate },
-                viewBox: exportChart.viewBox || null
-            }))}${SCRIPT_CLOSE_TAG}`
-            : '';
         const viewBoxAttr = exportChart.viewBox ? htmlEscape(`${exportChart.viewBox.width},${exportChart.viewBox.height}`) : '';
-        const canvasAttrs = hasHoverPayload
-            ? `class="line-canvas" role="img" aria-label="${ariaAttr}" data-viewbox="${viewBoxAttr}" data-line-payload="${htmlEscape(payloadId)}"`
-            : `class="line-canvas" role="img" aria-label="${ariaAttr}"`;
-        return `<div class="line-export">${legend}<div ${canvasAttrs}>${exportChart.svg}</div>${payloadScript}${footnote}</div>`;
+        let canvasAttrs = `class="line-canvas" role="img" aria-label="${ariaAttr}" data-viewbox="${viewBoxAttr}"`;
+        if (hasHoverPayload) {
+            const payload = { points: exportChart.hoverPoints || [], meta: { locale: currencyFormat.locale || 'cs-CZ', generic: exportChart.hoverTemplate }, viewBox: exportChart.viewBox || null };
+            const payloadJson = JSON.stringify(payload);
+            const metaJson = JSON.stringify(payload.meta);
+            const b64 = btoa(unescape(encodeURIComponent(payloadJson)));
+            const metaB64 = btoa(unescape(encodeURIComponent(metaJson)));
+            canvasAttrs += ` data-line-points-b64="${htmlEscape(b64)}" data-line-meta-b64="${htmlEscape(metaB64)}" data-encoding="b64"`;
+        }
+        canvasAttrs += '>';
+        return `<div class="line-export">${legend}<div ${canvasAttrs}${exportChart.svg}</div>${footnote}</div>`;
     }
 
     if (!container) return;

--- a/index.html
+++ b/index.html
@@ -2148,20 +2148,20 @@ document.addEventListener('DOMContentLoaded', () => {
             : `<div class="line-legend"><span class="legend-pill legend-pill--base" tabindex="0">${baseLegend}</span></div>`;
         const footnote = exportChart.footnote ? `<p class="chart-footnote">${htmlEscape(exportChart.footnote)}</p>` : '';
         const ariaAttr = htmlEscape(exportChart.ariaLabel || 'Vývoj portfolia');
-        /* PATCH: embed hover payloads via base64 data attributes for reliable tooltip hydration */
+        /* PATCH: embed hover payloads via inline JSON so export tooltips stay reliable */
         const hasHoverPayload = Array.isArray(exportChart.hoverPoints) && exportChart.hoverPoints.length > 0;
         const viewBoxAttr = exportChart.viewBox ? htmlEscape(`${exportChart.viewBox.width},${exportChart.viewBox.height}`) : '';
         let canvasAttrs = `class="line-canvas" role="img" aria-label="${ariaAttr}" data-viewbox="${viewBoxAttr}"`;
+        let payloadScript = '';
         if (hasHoverPayload) {
+            const payloadId = `line-hover-${Date.now()}-${Math.random().toString(36).slice(2, 8)}`;
             const payload = { points: exportChart.hoverPoints || [], meta: { locale: currencyFormat.locale || 'cs-CZ', generic: exportChart.hoverTemplate }, viewBox: exportChart.viewBox || null };
             const payloadJson = JSON.stringify(payload);
-            const metaJson = JSON.stringify(payload.meta);
-            const b64 = btoa(unescape(encodeURIComponent(payloadJson)));
-            const metaB64 = btoa(unescape(encodeURIComponent(metaJson)));
-            canvasAttrs += ` data-line-points-b64="${htmlEscape(b64)}" data-line-meta-b64="${htmlEscape(metaB64)}" data-encoding="b64"`;
+            canvasAttrs += ` data-line-payload="${payloadId}" data-encoding="json"`;
+            payloadScript = `<script type="application/json" id="${payloadId}">${htmlEscape(payloadJson)}${SCRIPT_CLOSE_TAG}`;
         }
         canvasAttrs += '>';
-        return `<div class="line-export">${legend}<div ${canvasAttrs}${exportChart.svg}</div>${footnote}</div>`;
+        return `<div class="line-export">${legend}<div ${canvasAttrs}${exportChart.svg}</div>${payloadScript}${footnote}</div>`;
     }
 
     if (!container) return;

--- a/index.html
+++ b/index.html
@@ -2364,12 +2364,7 @@ document.addEventListener('DOMContentLoaded', () => {
         ? `Vývoj portfolia v období ${startLabel} – ${endLabel}; dnešní hodnota ${formattedTodayValue}; XIRR ${formatXirr1(portfolioIrr)}`
         : `Vývoj portfolia v období ${startLabel} – ${endLabel}; dnešní hodnota ${formattedTodayValue}; XIRR není k dispozici.`;
     svg.setAttribute('role', 'img');
-    let svgTitle = svg.querySelector('title');
-    if (!svgTitle) {
-        svgTitle = document.createElementNS('http://www.w3.org/2000/svg', 'title');
-        svg.insertBefore(svgTitle, svg.firstChild);
-    }
-    svgTitle.textContent = ariaSummary;
+    /* PATCH: avoid native title tooltips, keep aria-label only */
     if (container) {
         container.setAttribute('role', 'img');
         container.setAttribute('aria-label', ariaSummary);
@@ -2394,13 +2389,13 @@ document.addEventListener('DOMContentLoaded', () => {
         svg.appendChild(interactionLayer);
         interactionLayer.addEventListener('mousemove', (e) => {
             const x = e.offsetX;
-            const snapThreshold = 10;
+            const snapThreshold = 6;
             let finalX = x, finalY, finalDate, finalValue, tooltipText;
             let closestSnapPoint = null;
             let minDistance = snapThreshold;
             snapPoints.forEach(p => {
                 const dist = Math.abs(x - p.x);
-                if (dist < minDistance) {
+                if (dist < minDistance || (dist === minDistance && closestSnapPoint && p.value > closestSnapPoint.value)) {
                     minDistance = dist;
                     closestSnapPoint = p;
                 }
@@ -2644,7 +2639,6 @@ document.addEventListener('DOMContentLoaded', () => {
               : `${name} • ${amountLabel} (${percentLabel})`;
           return `<g class="pie-slice" tabindex="0" aria-label="${htmlEscape(tooltip)}" data-tooltip-text="${htmlEscape(tooltip)}">
             <path d="M ${x1Outer},${y1Outer} A ${outerRadius},${outerRadius} 0 ${largeArc},1 ${x2Outer},${y2Outer} L ${x2Inner},${y2Inner} A ${innerRadius},${innerRadius} 0 ${largeArc},0 ${x1Inner},${y1Inner} Z" fill="${color}" stroke="#fff" stroke-width="2" />
-            <title>${htmlEscape(tooltip)}</title>
           </g>`;
       }).join('');
       const backdrop = `<circle cx="50" cy="50" r="${outerRadius}" fill="rgba(240,253,250,0.65)" />`;
@@ -2902,8 +2896,7 @@ document.addEventListener('DOMContentLoaded', () => {
           ? (copy.aria?.withIrr ? copy.aria.withIrr(startLabel, endLabel, formattedTodayValue, formatXirr1(irr, percentFormat)) : `Vývoj portfolia v období ${startLabel} – ${endLabel}; dnešní hodnota ${formattedTodayValue}; XIRR ${formatXirr1(irr, percentFormat)}`)
           : (copy.aria?.withoutIrr ? copy.aria.withoutIrr(startLabel, endLabel, formattedTodayValue) : `Vývoj portfolia v období ${startLabel} – ${endLabel}; dnešní hodnota ${formattedTodayValue}; XIRR není k dispozici.`);
       const svg = `
-        <svg viewBox="0 0 ${width} ${height}">
-          <title>${htmlEscape(ariaLabel)}</title>
+        <svg viewBox="0 0 ${width} ${height}" aria-label="${htmlEscape(ariaLabel)}" role="img">
           ${defs}
           <rect x="0" y="0" width="${width}" height="${height}" fill="url(#chartBackdrop)" rx="26" />
           <rect x="${margin.left - 8}" y="${margin.top - 12}" width="${chartWidth + 16}" height="${chartHeight + 24}" rx="22" fill="rgba(255,255,255,0.78)" stroke="rgba(148,163,184,0.25)" />

--- a/index.html
+++ b/index.html
@@ -2151,8 +2151,18 @@ document.addEventListener('DOMContentLoaded', () => {
         /* PATCH: embed hover payloads via JSON blocks (avoid attribute encoding issues) */
         const viewBoxPayload = exportChart.viewBox ? `${exportChart.viewBox.width},${exportChart.viewBox.height}` : '';
         const hasHoverPayload = Array.isArray(exportChart.hoverPoints) && exportChart.hoverPoints.length > 0;
+        /* PATCH: base64 payloads to survive serialization */
+        const encodePayload = (obj) => {
+            try {
+                return btoa(unescape(encodeURIComponent(JSON.stringify(obj || {}))));
+            } catch (_e) {
+                return '';
+            }
+        };
         const dataId = hasHoverPayload ? `line-data-${Date.now()}-${Math.random().toString(36).slice(2)}` : '';
         const metaId = hasHoverPayload ? `${dataId}-meta` : '';
+        const dataB64 = hasHoverPayload ? encodePayload(exportChart.hoverPoints || []) : '';
+        const metaB64 = hasHoverPayload ? encodePayload({ locale: currencyFormat.locale || 'cs-CZ', generic: exportChart.hoverTemplate }) : '';
         const safeJson = (payload) => String(payload || '')
             .replace(/</g, '\\u003c')
             .replace(/<\/script>/gi, '<\\/script>');
@@ -2164,7 +2174,7 @@ document.addEventListener('DOMContentLoaded', () => {
             : '';
         const viewBoxAttr = viewBoxPayload ? htmlEscape(viewBoxPayload) : '';
         const canvasAttrs = hasHoverPayload
-            ? `class="line-canvas" role="img" aria-label="${ariaAttr}" data-viewbox="${viewBoxAttr}" data-line-data="${htmlEscape(dataId)}" data-line-meta-id="${htmlEscape(metaId)}"`
+            ? `class="line-canvas" role="img" aria-label="${ariaAttr}" data-viewbox="${viewBoxAttr}" data-line-data="${htmlEscape(dataId)}" data-line-meta-id="${htmlEscape(metaId)}" data-line-points-b64="${htmlEscape(dataB64)}" data-line-meta-b64="${htmlEscape(metaB64)}"`
             : `class="line-canvas" role="img" aria-label="${ariaAttr}"`;
         return `<div class="line-export">${legend}<div ${canvasAttrs}>${exportChart.svg}</div>${dataScript}${metaScript}${footnote}</div>`;
     }
@@ -3663,9 +3673,13 @@ document.addEventListener('DOMContentLoaded', () => {
             for(const attempt of attempts){try{return attempt();}catch(_e){}}
             return null;
           };
-          document.querySelectorAll('.line-canvas[data-line-points], .line-canvas[data-line-data]').forEach(canvas=>{
+          document.querySelectorAll('.line-canvas[data-line-points], .line-canvas[data-line-data], .line-canvas[data-line-points-b64]').forEach(canvas=>{
             const encoding=canvas.getAttribute('data-encoding')||'uri';
             let pts=null;
+            const b64Attr=canvas.getAttribute('data-line-points-b64');
+            if(b64Attr){
+              pts=decodePayload(b64Attr,'b64');
+            }
             const dataId=canvas.getAttribute('data-line-data');
             if(dataId){
               const scriptEl=document.getElementById(dataId);
@@ -3680,6 +3694,10 @@ document.addEventListener('DOMContentLoaded', () => {
             if(!Array.isArray(pts)||!pts.length)return;
             /* PATCH */
             let meta=null;
+            const metaB64=canvas.getAttribute('data-line-meta-b64');
+            if(metaB64){
+              meta=decodePayload(metaB64,'b64');
+            }
             const metaId=canvas.getAttribute('data-line-meta-id');
             if(metaId){
               const metaEl=document.getElementById(metaId);

--- a/index.html
+++ b/index.html
@@ -2148,40 +2148,23 @@ document.addEventListener('DOMContentLoaded', () => {
             : `<div class="line-legend"><span class="legend-pill legend-pill--base" tabindex="0">${baseLegend}</span></div>`;
         const footnote = exportChart.footnote ? `<p class="chart-footnote">${htmlEscape(exportChart.footnote)}</p>` : '';
         const ariaAttr = htmlEscape(exportChart.ariaLabel || 'Vývoj portfolia');
-        /* PATCH */
-        /* PATCH: robust encoding for hover payloads (base64) */
-        const encodePayload = (obj) => {
-            try {
-                return btoa(unescape(encodeURIComponent(JSON.stringify(obj))));
-            } catch (_e) {
-                return '';
-            }
-        };
-        /* PATCH */
-        const pointsPayload = exportChart.hoverPoints
-            ? encodePayload(exportChart.hoverPoints)
-            : '';
-        /* PATCH */
+        /* PATCH: embed hover payloads via JSON blocks (avoid attribute encoding issues) */
         const viewBoxPayload = exportChart.viewBox ? `${exportChart.viewBox.width},${exportChart.viewBox.height}` : '';
-        /* PATCH */
-        const metaPayload = exportChart.hoverTemplate
-            ? encodePayload({
-                locale: currencyFormat.locale || 'cs-CZ',
-                generic: exportChart.hoverTemplate
-            })
-            : '';
-        /* PATCH: introduce JSON data blocks to avoid attribute corruption */
-        const dataId = pointsPayload ? `line-data-${Date.now()}-${Math.random().toString(36).slice(2)}` : '';
-        const metaId = metaPayload ? `${dataId || 'line-meta'}-meta` : '';
+        const hasHoverPayload = Array.isArray(exportChart.hoverPoints) && exportChart.hoverPoints.length > 0;
+        const dataId = hasHoverPayload ? `line-data-${Date.now()}-${Math.random().toString(36).slice(2)}` : '';
+        const metaId = hasHoverPayload ? `${dataId}-meta` : '';
         const safeJson = (payload) => String(payload || '')
             .replace(/</g, '\\u003c')
             .replace(/<\/script>/gi, '<\\/script>');
-        const dataScript = pointsPayload ? `<script type="application/json" id="${dataId}">${safeJson(exportChart.hoverPoints ? JSON.stringify(exportChart.hoverPoints) : '')}</script>` : '';
-        const metaScript = metaPayload ? `<script type="application/json" id="${metaId}">${safeJson(exportChart.hoverTemplate ? JSON.stringify({ locale: currencyFormat.locale || 'cs-CZ', generic: exportChart.hoverTemplate }) : '')}</script>` : '';
+        const dataScript = hasHoverPayload
+            ? `<script type="application/json" id="${dataId}">${safeJson(JSON.stringify(exportChart.hoverPoints || []))}</script>`
+            : '';
+        const metaScript = hasHoverPayload
+            ? `<script type="application/json" id="${metaId}">${safeJson(JSON.stringify({ locale: currencyFormat.locale || 'cs-CZ', generic: exportChart.hoverTemplate }))}</script>`
+            : '';
         const viewBoxAttr = viewBoxPayload ? htmlEscape(viewBoxPayload) : '';
-        /* PATCH */
-        const canvasAttrs = pointsPayload
-            ? `class="line-canvas" role="img" aria-label="${ariaAttr}" data-viewbox="${viewBoxAttr}" data-line-data="${htmlEscape(dataId)}" ${metaId ? `data-line-meta-id="${htmlEscape(metaId)}"` : ''}`
+        const canvasAttrs = hasHoverPayload
+            ? `class="line-canvas" role="img" aria-label="${ariaAttr}" data-viewbox="${viewBoxAttr}" data-line-data="${htmlEscape(dataId)}" data-line-meta-id="${htmlEscape(metaId)}"`
             : `class="line-canvas" role="img" aria-label="${ariaAttr}"`;
         return `<div class="line-export">${legend}<div ${canvasAttrs}>${exportChart.svg}</div>${dataScript}${metaScript}${footnote}</div>`;
     }


### PR DESCRIPTION
## Summary
- remove native SVG title tooltips from exported line-chart points to avoid double popovers
- retain aria labels on hover markers while keeping today and projection dots accessible

## Testing
- node - <<'NODE'
const fs=require('fs');
const html=fs.readFileSync('index.html','utf8');
const start=html.indexOf('<script>');
const end=html.lastIndexOf('</script>');
if(start===-1||end===-1) throw new Error('script tags not found');
const script=html.slice(start+'<script>'.length,end);
new Function(script);
console.log('script parse ok');
NODE

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_68e3be050394832a8548be6ba9151e5e)